### PR TITLE
refactor: TransactionTemplate을 Facade 패턴으로 대체

### DIFF
--- a/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/controller/CctvController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/controller/CctvController.kt
@@ -4,7 +4,7 @@ import com.pluxity.common.core.response.DataResponseBody
 import com.pluxity.common.core.response.ErrorResponseBody
 import com.pluxity.safers.cctv.dto.CctvResponse
 import com.pluxity.safers.cctv.dto.CctvUpdateRequest
-import com.pluxity.safers.cctv.service.CctvService
+import com.pluxity.safers.cctv.service.CctvFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/cctvs")
 @Tag(name = "CCTV Controller", description = "CCTV 관리 API")
 class CctvController(
-    private val service: CctvService,
+    private val service: CctvFacade,
 ) {
     @Operation(summary = "CCTV 동기화", description = "미디어서버에서 CCTV 경로 목록을 가져와 DB에 동기화합니다")
     @ApiResponses(

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/service/CctvFacade.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/service/CctvFacade.kt
@@ -1,0 +1,62 @@
+package com.pluxity.safers.cctv.service
+
+import com.pluxity.common.core.exception.CustomException
+import com.pluxity.safers.cctv.client.CctvApiClient
+import com.pluxity.safers.cctv.config.CctvErrorCode
+import com.pluxity.safers.cctv.dto.CctvResponse
+import com.pluxity.safers.cctv.dto.CctvUpdateRequest
+import com.pluxity.safers.site.repository.SiteRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class CctvFacade(
+    private val cctvService: CctvService,
+    private val siteRepository: SiteRepository,
+    private val apiClient: CctvApiClient,
+) {
+    fun sync(siteId: Long? = null) {
+        val sites =
+            if (siteId != null) {
+                val site =
+                    siteRepository.findByIdOrNull(siteId)
+                        ?: throw CustomException(CctvErrorCode.NOT_FOUND_SITE, siteId)
+                listOf(site)
+            } else {
+                siteRepository.findAll()
+            }
+
+        val sitePathsMap =
+            runBlocking(Dispatchers.IO) {
+                sites
+                    .mapNotNull { site -> site.baseUrl?.let { site to it } }
+                    .map { (site, baseUrl) ->
+                        async {
+                            try {
+                                site to apiClient.fetchPaths(baseUrl, site.requiredId)
+                            } catch (e: Exception) {
+                                log.warn(e) { "Site ${site.requiredId}(${site.name})의 미디어서버($baseUrl) 경로 조회 실패" }
+                                null
+                            }
+                        }
+                    }.awaitAll()
+                    .filterNotNull()
+            }
+
+        cctvService.syncAll(sitePathsMap)
+    }
+
+    fun findAll(siteId: Long? = null): List<CctvResponse> = cctvService.findAll(siteId)
+
+    fun update(
+        id: Long,
+        request: CctvUpdateRequest,
+    ) = cctvService.update(id, request)
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/service/CctvService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/service/CctvService.kt
@@ -4,7 +4,6 @@ import com.pluxity.common.core.exception.CustomException
 import com.pluxity.common.core.utils.findAllNotNull
 import com.pluxity.common.file.extensions.getFileMapById
 import com.pluxity.common.file.service.FileService
-import com.pluxity.safers.cctv.client.CctvApiClient
 import com.pluxity.safers.cctv.config.CctvErrorCode
 import com.pluxity.safers.cctv.dto.CctvResponse
 import com.pluxity.safers.cctv.dto.CctvUpdateRequest
@@ -13,59 +12,20 @@ import com.pluxity.safers.cctv.dto.toResponse
 import com.pluxity.safers.cctv.entity.Cctv
 import com.pluxity.safers.cctv.repository.CctvRepository
 import com.pluxity.safers.site.entity.Site
-import com.pluxity.safers.site.repository.SiteRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionTemplate
-
-private val log = KotlinLogging.logger {}
 
 @Service
+@Transactional(readOnly = true)
 class CctvService(
     private val repository: CctvRepository,
-    private val siteRepository: SiteRepository,
     private val fileService: FileService,
-    private val apiClient: CctvApiClient,
-    private val transactionTemplate: TransactionTemplate,
 ) {
-    fun sync(siteId: Long? = null) {
-        val sites =
-            if (siteId != null) {
-                val site =
-                    siteRepository.findByIdOrNull(siteId)
-                        ?: throw CustomException(CctvErrorCode.NOT_FOUND_SITE, siteId)
-                listOf(site)
-            } else {
-                siteRepository.findAll()
-            }
-
-        val sitePathsMap =
-            runBlocking(Dispatchers.IO) {
-                sites
-                    .mapNotNull { site -> site.baseUrl?.let { site to it } }
-                    .map { (site, baseUrl) ->
-                        async {
-                            try {
-                                site to apiClient.fetchPaths(baseUrl, site.requiredId)
-                            } catch (e: Exception) {
-                                log.warn(e) { "Site ${site.requiredId}(${site.name})의 미디어서버($baseUrl) 경로 조회 실패" }
-                                null
-                            }
-                        }
-                    }.awaitAll()
-                    .filterNotNull()
-            }
-
-        transactionTemplate.executeWithoutResult {
-            sitePathsMap.forEach { (site, externalPaths) ->
-                syncForSite(site, externalPaths)
-            }
+    @Transactional
+    fun syncAll(sitePathsMap: List<Pair<Site, List<MediaServerPathItem>>>) {
+        sitePathsMap.forEach { (site, externalPaths) ->
+            syncForSite(site, externalPaths)
         }
     }
 
@@ -93,7 +53,6 @@ class CctvService(
         }
     }
 
-    @Transactional(readOnly = true)
     fun findAll(siteId: Long? = null): List<CctvResponse> {
         val cctvList =
             repository.findAllNotNull {

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/controller/EventController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/controller/EventController.kt
@@ -11,7 +11,7 @@ import com.pluxity.safers.event.dto.EventResponse
 import com.pluxity.safers.event.dto.EventVideoUploadRequest
 import com.pluxity.safers.event.dto.toResponse
 import com.pluxity.safers.event.entity.EventCategory
-import com.pluxity.safers.event.service.EventService
+import com.pluxity.safers.event.service.EventFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/events")
 @Tag(name = "Event Controller", description = "이벤트 관리 API")
 class EventController(
-    private val eventService: EventService,
+    private val eventFacade: EventFacade,
 ) {
     @Operation(summary = "이벤트 등록", description = "외부 시스템에서 감지된 이벤트를 등록합니다")
     @ApiResponses(
@@ -71,7 +71,7 @@ class EventController(
         @RequestBody
         @Valid
         request: EventCreateRequest,
-    ): ResponseEntity<Long> = ResponseEntity.ok(eventService.create(request))
+    ): ResponseEntity<Long> = ResponseEntity.ok(eventFacade.create(request))
 
     @Operation(summary = "이벤트 목록 조회", description = "모든 이벤트 목록을 조회합니다")
     @ApiResponses(
@@ -107,7 +107,7 @@ class EventController(
         @RequestParam(required = false)
         endDate: String? = null,
     ): ResponseEntity<DataResponseBody<PageResponse<EventResponse>>> =
-        ResponseEntity.ok(DataResponseBody(eventService.findAll(PageSearchRequest(page, size), startDate, endDate)))
+        ResponseEntity.ok(DataResponseBody(eventFacade.findAll(PageSearchRequest(page, size), startDate, endDate)))
 
     @Operation(summary = "이벤트 상세 조회", description = "ID로 특정 이벤트의 상세 정보를 조회합니다")
     @ApiResponses(
@@ -143,7 +143,7 @@ class EventController(
         @PathVariable
         @Parameter(description = "이벤트 ID", required = true)
         id: Long,
-    ): ResponseEntity<DataResponseBody<EventResponse>> = ResponseEntity.ok(DataResponseBody(eventService.findById(id)))
+    ): ResponseEntity<DataResponseBody<EventResponse>> = ResponseEntity.ok(DataResponseBody(eventFacade.findById(id)))
 
     @Operation(summary = "이벤트 영상 등록", description = "외부 시스템의 영상 파일을 다운로드하여 이벤트에 등록합니다")
     @ApiResponses(
@@ -183,7 +183,7 @@ class EventController(
         @Valid
         request: EventVideoUploadRequest,
     ): ResponseEntity<Void> {
-        eventService.uploadVideo(eventId, request.video)
+        eventFacade.uploadVideo(eventId, request.video)
         return ResponseEntity.ok().build()
     }
 

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventFacade.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventFacade.kt
@@ -1,0 +1,34 @@
+package com.pluxity.safers.event.service
+
+import com.pluxity.common.core.dto.PageSearchRequest
+import com.pluxity.common.core.response.PageResponse
+import com.pluxity.safers.event.dto.EventCreateRequest
+import com.pluxity.safers.event.dto.EventResponse
+import org.springframework.stereotype.Component
+
+@Component
+class EventFacade(
+    private val eventService: EventService,
+    private val eventFileDownloadService: EventFileDownloadService,
+) {
+    fun create(request: EventCreateRequest): Long {
+        val snapshotFileId = eventFileDownloadService.downloadAndInitiateUpload("/snapshots/", request.snapshot)
+        return eventService.create(request, snapshotFileId)
+    }
+
+    fun uploadVideo(
+        eventId: Long,
+        videoFileName: String,
+    ) {
+        val videoFileId = eventFileDownloadService.downloadAndInitiateUpload("/videos/", videoFileName)
+        eventService.uploadVideo(eventId, videoFileId)
+    }
+
+    fun findById(id: Long): EventResponse = eventService.findById(id)
+
+    fun findAll(
+        request: PageSearchRequest,
+        startDate: String? = null,
+        endDate: String? = null,
+    ): PageResponse<EventResponse> = eventService.findAll(request, startDate, endDate)
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventService.kt
@@ -20,78 +20,72 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
+@Transactional(readOnly = true)
 class EventService(
     private val eventRepository: EventRepository,
     private val fileService: FileService,
-    private val eventFileDownloadService: EventFileDownloadService,
     private val eventPublisher: ApplicationEventPublisher,
-    private val transactionTemplate: TransactionTemplate,
 ) {
     companion object {
         private const val EVENT_PATH = "events/"
     }
 
-    fun create(request: EventCreateRequest): Long {
-        val snapshotFileId = eventFileDownloadService.downloadAndInitiateUpload("/snapshots/", request.snapshot)
+    @Transactional
+    fun create(
+        request: EventCreateRequest,
+        snapshotFileId: Long?,
+    ): Long {
+        val event =
+            Event(
+                eventId = request.eventId,
+                eventTimestamp = request.timestamp,
+                category = request.category,
+                type = request.type,
+                trackId = request.trackId,
+                name = request.name,
+                bbox = request.bbox?.toString(),
+                centerX = request.center?.x,
+                centerY = request.center?.y,
+                confidence = request.confidence,
+                path = request.path,
+            )
 
-        return transactionTemplate.execute {
-            val event =
-                Event(
-                    eventId = request.eventId,
-                    eventTimestamp = request.timestamp,
-                    category = request.category,
-                    type = request.type,
-                    trackId = request.trackId,
-                    name = request.name,
-                    bbox = request.bbox?.toString(),
-                    centerX = request.center?.x,
-                    centerY = request.center?.y,
-                    confidence = request.confidence,
-                    path = request.path,
-                )
+        val savedEvent = eventRepository.save(event)
 
-            val savedEvent = eventRepository.save(event)
-
-            snapshotFileId?.let {
-                fileService.finalizeUpload(it, "$EVENT_PATH${savedEvent.requiredId}/")
-            }
-            savedEvent.assignSnapshotFile(snapshotFileId)
-
-            val fileResponse = fileService.getFileResponse(snapshotFileId)
-            eventPublisher.publishEvent(EventCreated(savedEvent.toResponse(fileResponse)))
-
-            savedEvent.requiredId
+        snapshotFileId?.let {
+            fileService.finalizeUpload(it, "$EVENT_PATH${savedEvent.requiredId}/")
         }
+        savedEvent.assignSnapshotFile(snapshotFileId)
+
+        val fileResponse = fileService.getFileResponse(snapshotFileId)
+        eventPublisher.publishEvent(EventCreated(savedEvent.toResponse(fileResponse)))
+
+        return savedEvent.requiredId
     }
 
+    @Transactional
     fun uploadVideo(
         eventId: Long,
-        videoFileName: String,
+        videoFileId: Long?,
     ) {
-        val videoFileId = eventFileDownloadService.downloadAndInitiateUpload("/videos/", videoFileName)
+        val event =
+            eventRepository.findByIdOrNull(eventId)
+                ?: throw CustomException(SafersErrorCode.NOT_FOUND_EVENT, eventId)
 
-        transactionTemplate.executeWithoutResult {
-            val event =
-                eventRepository.findByIdOrNull(eventId)
-                    ?: throw CustomException(SafersErrorCode.NOT_FOUND_EVENT, eventId)
+        event.assignVideoFile(videoFileId)
 
-            event.assignVideoFile(videoFileId)
-
-            videoFileId?.let {
-                fileService.finalizeUpload(it, "$EVENT_PATH$eventId/")
-                val snapshotFileResponse = fileService.getFileResponse(event.snapshotFileId)
-                val videoFileResponse = fileService.getFileResponse(it)
-                eventPublisher.publishEvent(EventVideoRegistered(event.toResponse(snapshotFileResponse, videoFileResponse)))
-            }
+        videoFileId?.let {
+            fileService.finalizeUpload(it, "$EVENT_PATH$eventId/")
+            val snapshotFileResponse = fileService.getFileResponse(event.snapshotFileId)
+            val videoFileResponse = fileService.getFileResponse(it)
+            eventPublisher.publishEvent(EventVideoRegistered(event.toResponse(snapshotFileResponse, videoFileResponse)))
         }
     }
 
-    @Transactional(readOnly = true)
     fun findById(id: Long): EventResponse {
         val event =
             eventRepository.findByIdOrNull(id)
@@ -102,7 +96,6 @@ class EventService(
         return event.toResponse(snapshotFileResponse, videoFileResponse)
     }
 
-    @Transactional(readOnly = true)
     fun findAll(
         request: PageSearchRequest,
         startDate: String? = null,

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/scheduler/WeatherScheduler.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/scheduler/WeatherScheduler.kt
@@ -1,20 +1,20 @@
 package com.pluxity.safers.weather.scheduler
 
-import com.pluxity.safers.weather.service.WeatherService
+import com.pluxity.safers.weather.service.WeatherFacade
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
 class WeatherScheduler(
-    private val weatherService: WeatherService,
+    private val weatherFacade: WeatherFacade,
 ) {
     @Scheduled(cron = "0 45 * * * *")
     fun collectForecast() {
-        weatherService.collectForecast()
+        weatherFacade.collectForecast()
     }
 
     @Scheduled(cron = "0 10 * * * *")
     fun collectObservation() {
-        weatherService.collectObservation()
+        weatherFacade.collectObservation()
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/service/WeatherFacade.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/service/WeatherFacade.kt
@@ -1,0 +1,77 @@
+package com.pluxity.safers.weather.service
+
+import com.pluxity.safers.site.repository.SiteRepository
+import com.pluxity.safers.weather.client.WeatherApiClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class WeatherFacade(
+    private val weatherService: WeatherService,
+    private val weatherApiClient: WeatherApiClient,
+    private val siteRepository: SiteRepository,
+) {
+    companion object {
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+        private val HOUR_FORMATTER = DateTimeFormatter.ofPattern("HH")
+    }
+
+    fun collectForecast() {
+        val sites = siteRepository.findAll().filter { it.nx != 0 }
+        if (sites.isEmpty()) {
+            log.info { "등록된 현장이 없어 초단기 예보 수집을 건너뜁니다." }
+            return
+        }
+
+        val now = LocalDateTime.now()
+        val baseDate = now.format(DATE_FORMATTER)
+        val baseTime = now.format(HOUR_FORMATTER) + "30"
+
+        log.info { "초단기 예보 수집 시작 - baseDate: $baseDate, baseTime: $baseTime, 현장 수: ${sites.size}" }
+
+        val results =
+            Flux
+                .fromIterable(sites)
+                .flatMap({ site ->
+                    weatherApiClient
+                        .fetchUltraSrtFcst(baseDate, baseTime, site.nx, site.ny)
+                        .map { site to it }
+                }, 4)
+                .collectList()
+                .block() ?: return
+
+        weatherService.saveForecastData(results)
+    }
+
+    fun collectObservation() {
+        val sites = siteRepository.findAll().filter { it.nx != 0 }
+        if (sites.isEmpty()) {
+            log.info { "등록된 현장이 없어 초단기 실황 수집을 건너뜁니다." }
+            return
+        }
+
+        val now = LocalDateTime.now()
+        val baseDate = now.format(DATE_FORMATTER)
+        val baseTime = now.format(HOUR_FORMATTER) + "00"
+
+        log.info { "초단기 실황 수집 시작 - baseDate: $baseDate, baseTime: $baseTime, 현장 수: ${sites.size}" }
+
+        val results =
+            Flux
+                .fromIterable(sites)
+                .flatMap({ site ->
+                    weatherApiClient
+                        .fetchUltraSrtNcst(baseDate, baseTime, site.nx, site.ny)
+                        .map { site to it }
+                }, 4)
+                .collectList()
+                .block() ?: return
+
+        weatherService.saveObservationData(results)
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/service/WeatherService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/service/WeatherService.kt
@@ -1,7 +1,6 @@
 package com.pluxity.safers.weather.service
 
-import com.pluxity.safers.site.repository.SiteRepository
-import com.pluxity.safers.weather.client.WeatherApiClient
+import com.pluxity.safers.site.entity.Site
 import com.pluxity.safers.weather.dto.WeatherApiResponse
 import com.pluxity.safers.weather.dto.WeatherItemResponse
 import com.pluxity.safers.weather.dto.WeatherTimeGroupResponse
@@ -11,27 +10,20 @@ import com.pluxity.safers.weather.repository.WeatherRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionTemplate
-import reactor.core.publisher.Flux
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 private val log = KotlinLogging.logger {}
 
 @Service
+@Transactional(readOnly = true)
 class WeatherService(
     private val weatherRepository: WeatherRepository,
-    private val weatherApiClient: WeatherApiClient,
-    private val siteRepository: SiteRepository,
-    private val transactionTemplate: TransactionTemplate,
 ) {
     companion object {
-        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
-        private val HOUR_FORMATTER = DateTimeFormatter.ofPattern("HH")
         private val DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm")
     }
 
-    @Transactional(readOnly = true)
     fun findDashboard(siteId: Long): List<WeatherTimeGroupResponse> {
         val now = LocalDateTime.now()
         val startDateTime = now.minusHours(4).format(DATE_TIME_FORMATTER)
@@ -55,129 +47,81 @@ class WeatherService(
             }
     }
 
-    fun collectForecast() {
-        val sites = siteRepository.findAll().filter { it.nx != 0 }
-        if (sites.isEmpty()) {
-            log.info { "등록된 현장이 없어 초단기 예보 수집을 건너뜁니다." }
-            return
-        }
+    @Transactional
+    fun saveForecastData(results: List<Pair<Site, WeatherApiResponse>>) {
+        results.forEach { (site, response) ->
+            val items = extractItems(response) ?: return@forEach
+            val fcstDates = items.mapNotNull { it.fcstDate }.toSet()
+            val existingMap =
+                weatherRepository
+                    .findBySiteAndFcstDateIn(site, fcstDates)
+                    .associateBy { Triple(it.fcstDate, it.fcstTime, it.category) }
 
-        val now = LocalDateTime.now()
-        val baseDate = now.format(DATE_FORMATTER)
-        val baseTime = now.format(HOUR_FORMATTER) + "30"
+            items.forEach { item ->
+                val category = WeatherCategory.fromName(item.category) ?: return@forEach
+                val fcstDate = item.fcstDate ?: return@forEach
+                val fcstTime = item.fcstTime ?: return@forEach
+                val fcstValue = item.fcstValue ?: return@forEach
 
-        log.info { "초단기 예보 수집 시작 - baseDate: $baseDate, baseTime: $baseTime, 현장 수: ${sites.size}" }
-
-        val results =
-            Flux
-                .fromIterable(sites)
-                .flatMap({ site ->
-                    weatherApiClient
-                        .fetchUltraSrtFcst(baseDate, baseTime, site.nx, site.ny)
-                        .map { site to it }
-                }, 4)
-                .collectList()
-                .block() ?: return
-
-        transactionTemplate.execute {
-            results.forEach { (site, response) ->
-                val items = extractItems(response) ?: return@forEach
-                val fcstDates = items.mapNotNull { it.fcstDate }.toSet()
-                val existingMap =
-                    weatherRepository
-                        .findBySiteAndFcstDateIn(site, fcstDates)
-                        .associateBy { Triple(it.fcstDate, it.fcstTime, it.category) }
-
-                items.forEach { item ->
-                    val category = WeatherCategory.fromName(item.category) ?: return@forEach
-                    val fcstDate = item.fcstDate ?: return@forEach
-                    val fcstTime = item.fcstTime ?: return@forEach
-                    val fcstValue = item.fcstValue ?: return@forEach
-
-                    val existing = existingMap[Triple(fcstDate, fcstTime, category)]
-                    if (existing != null) {
-                        existing.baseDate = item.baseDate
-                        existing.baseTime = item.baseTime
-                        existing.fcstValue = fcstValue
-                    } else {
-                        weatherRepository.save(
-                            Weather(
-                                site = site,
-                                baseDate = item.baseDate,
-                                baseTime = item.baseTime,
-                                category = category,
-                                fcstDate = fcstDate,
-                                fcstTime = fcstTime,
-                                fcstValue = fcstValue,
-                            ),
-                        )
-                    }
+                val existing = existingMap[Triple(fcstDate, fcstTime, category)]
+                if (existing != null) {
+                    existing.baseDate = item.baseDate
+                    existing.baseTime = item.baseTime
+                    existing.fcstValue = fcstValue
+                } else {
+                    weatherRepository.save(
+                        Weather(
+                            site = site,
+                            baseDate = item.baseDate,
+                            baseTime = item.baseTime,
+                            category = category,
+                            fcstDate = fcstDate,
+                            fcstTime = fcstTime,
+                            fcstValue = fcstValue,
+                        ),
+                    )
                 }
-
-                log.info { "초단기 예보 수집 완료 - 현장: ${site.name}, nx: ${site.nx}, ny: ${site.ny}" }
             }
+
+            log.info { "초단기 예보 수집 완료 - 현장: ${site.name}, nx: ${site.nx}, ny: ${site.ny}" }
         }
     }
 
-    fun collectObservation() {
-        val sites = siteRepository.findAll().filter { it.nx != 0 }
-        if (sites.isEmpty()) {
-            log.info { "등록된 현장이 없어 초단기 실황 수집을 건너뜁니다." }
-            return
-        }
+    @Transactional
+    fun saveObservationData(results: List<Pair<Site, WeatherApiResponse>>) {
+        results.forEach { (site, response) ->
+            val items = extractItems(response) ?: return@forEach
+            val fcstDates = items.map { it.baseDate }.toSet()
+            val existingMap =
+                weatherRepository
+                    .findBySiteAndFcstDateIn(site, fcstDates)
+                    .associateBy { Triple(it.fcstDate, it.fcstTime, it.category) }
 
-        val now = LocalDateTime.now()
-        val baseDate = now.format(DATE_FORMATTER)
-        val baseTime = now.format(HOUR_FORMATTER) + "00"
+            items.forEach { item ->
+                val category = WeatherCategory.fromName(item.category) ?: return@forEach
+                val obsrValue = item.obsrValue ?: return@forEach
 
-        log.info { "초단기 실황 수집 시작 - baseDate: $baseDate, baseTime: $baseTime, 현장 수: ${sites.size}" }
-
-        val results =
-            Flux
-                .fromIterable(sites)
-                .flatMap({ site ->
-                    weatherApiClient
-                        .fetchUltraSrtNcst(baseDate, baseTime, site.nx, site.ny)
-                        .map { site to it }
-                }, 4)
-                .collectList()
-                .block() ?: return
-
-        transactionTemplate.execute {
-            results.forEach { (site, response) ->
-                val items = extractItems(response) ?: return@forEach
-                val fcstDates = items.map { it.baseDate }.toSet()
-                val existingMap =
-                    weatherRepository
-                        .findBySiteAndFcstDateIn(site, fcstDates)
-                        .associateBy { Triple(it.fcstDate, it.fcstTime, it.category) }
-
-                items.forEach { item ->
-                    val category = WeatherCategory.fromName(item.category) ?: return@forEach
-                    val obsrValue = item.obsrValue ?: return@forEach
-
-                    val existing = existingMap[Triple(item.baseDate, item.baseTime, category)]
-                    if (existing != null) {
-                        existing.baseDate = item.baseDate
-                        existing.baseTime = item.baseTime
-                        existing.fcstValue = obsrValue
-                    } else {
-                        weatherRepository.save(
-                            Weather(
-                                site = site,
-                                baseDate = item.baseDate,
-                                baseTime = item.baseTime,
-                                category = category,
-                                fcstDate = item.baseDate,
-                                fcstTime = item.baseTime,
-                                fcstValue = obsrValue,
-                            ),
-                        )
-                    }
+                val existing = existingMap[Triple(item.baseDate, item.baseTime, category)]
+                if (existing != null) {
+                    existing.baseDate = item.baseDate
+                    existing.baseTime = item.baseTime
+                    existing.fcstValue = obsrValue
+                } else {
+                    weatherRepository.save(
+                        Weather(
+                            site = site,
+                            baseDate = item.baseDate,
+                            baseTime = item.baseTime,
+                            category = category,
+                            fcstDate = item.baseDate,
+                            fcstTime = item.baseTime,
+                            fcstValue = obsrValue,
+                        ),
+                    )
                 }
-
-                log.info { "초단기 실황 수집 완료 - 현장: ${site.name}, nx: ${site.nx}, ny: ${site.ny}" }
             }
+
+            log.info { "초단기 실황 수집 완료 - 현장: ${site.name}, nx: ${site.nx}, ny: ${site.ny}" }
         }
     }
 

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/cctv/service/CctvServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/cctv/service/CctvServiceTest.kt
@@ -21,9 +21,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.transaction.TransactionStatus
-import org.springframework.transaction.support.TransactionTemplate
-import java.util.function.Consumer
 
 class CctvServiceTest :
     BehaviorSpec({
@@ -32,12 +29,8 @@ class CctvServiceTest :
         val siteRepository: SiteRepository = mockk(relaxed = true)
         val fileService: FileService = mockk(relaxed = true)
         val apiClient: CctvApiClient = mockk()
-        val transactionTemplate: TransactionTemplate = mockk()
-        val service = CctvService(repository, siteRepository, fileService, apiClient, transactionTemplate)
-
-        every { transactionTemplate.executeWithoutResult(any()) } answers {
-            firstArg<Consumer<TransactionStatus>>().accept(mockk())
-        }
+        val service = CctvService(repository, fileService)
+        val facade = CctvFacade(service, siteRepository, apiClient)
 
         val site = dummySite(id = 1L, baseUrl = "http://media-server:9997")
 
@@ -56,7 +49,7 @@ class CctvServiceTest :
                 every { apiClient.fetchPaths("http://media-server:9997", 1L) } returns externalPaths
                 every { repository.findBySiteId(1L) } returns emptyList()
 
-                service.sync(siteId = 1L)
+                facade.sync(siteId = 1L)
 
                 Then("새로운 CCTV가 저장된다") {
                     verify { repository.saveAll(match<List<Cctv>> { it.size == 2 }) }
@@ -73,7 +66,7 @@ class CctvServiceTest :
                 every { apiClient.fetchPaths("http://media-server:9997", 1L) } returns externalPaths
                 every { repository.findBySiteId(1L) } returns emptyList()
 
-                service.sync()
+                facade.sync()
 
                 Then("전체 site에 대해 동기화가 수행된다") {
                     verify { repository.saveAll(match<List<Cctv>> { it.size == 1 }) }
@@ -90,7 +83,7 @@ class CctvServiceTest :
                     )
                 every { repository.findBySiteId(1L) } returns listOf(existingCctv)
 
-                service.sync(siteId = 1L)
+                facade.sync(siteId = 1L)
 
                 Then("해당 CCTV가 삭제된다") {
                     verify { repository.deleteAllInBatch(match<List<Cctv>> { it.size == 1 && it[0].streamName == "cam_old" }) }
@@ -108,7 +101,7 @@ class CctvServiceTest :
                     )
                 every { repository.findBySiteId(1L) } returns listOf(existingCctv)
 
-                service.sync(siteId = 1L)
+                facade.sync(siteId = 1L)
 
                 Then("저장이나 삭제가 수행되지 않는다") {
                     verify(exactly = 0) { repository.saveAll(any<List<Cctv>>()) }
@@ -122,7 +115,7 @@ class CctvServiceTest :
                 Then("NOT_FOUND_SITE 예외가 발생한다") {
                     val exception =
                         shouldThrow<CustomException> {
-                            service.sync(siteId = 999L)
+                            facade.sync(siteId = 999L)
                         }
                     exception.code shouldBe CctvErrorCode.NOT_FOUND_SITE
                 }

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventServiceTest.kt
@@ -26,10 +26,6 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.transaction.TransactionStatus
-import org.springframework.transaction.support.TransactionCallback
-import org.springframework.transaction.support.TransactionTemplate
-import java.util.function.Consumer
 
 class EventServiceTest :
     BehaviorSpec({
@@ -40,24 +36,19 @@ class EventServiceTest :
         val fileService: FileService = mockk(relaxed = true)
         val eventFileDownloadService: EventFileDownloadService = mockk()
         val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
-        val transactionTemplate: TransactionTemplate = mockk()
 
         val service =
             EventService(
                 eventRepository,
                 fileService,
-                eventFileDownloadService,
                 eventPublisher,
-                transactionTemplate,
             )
 
-        every { transactionTemplate.execute(any<TransactionCallback<Long>>()) } answers {
-            firstArg<TransactionCallback<Long>>().doInTransaction(mockk())
-        }
-
-        every { transactionTemplate.executeWithoutResult(any()) } answers {
-            firstArg<Consumer<TransactionStatus>>().accept(mockk())
-        }
+        val facade =
+            EventFacade(
+                service,
+                eventFileDownloadService,
+            )
 
         Given("이벤트 생성") {
 
@@ -71,7 +62,7 @@ class EventServiceTest :
                 every { eventRepository.save(any()) } returns savedEvent
                 every { fileService.getFileResponse(snapshotFileId) } returns snapshotFileResponse
 
-                val result = service.create(request)
+                val result = facade.create(request)
 
                 Then("이벤트 ID가 반환된다") {
                     result shouldBe 1L
@@ -94,7 +85,7 @@ class EventServiceTest :
                 every { eventRepository.save(any()) } returns savedEvent
                 every { fileService.getFileResponse(null) } returns null
 
-                val result = service.create(request)
+                val result = facade.create(request)
 
                 Then("이벤트는 저장되지만 파일 업로드는 수행되지 않는다") {
                     result shouldBe 2L
@@ -117,7 +108,7 @@ class EventServiceTest :
                 every { fileService.getFileResponse(10L) } returns snapshotFileResponse
                 every { fileService.getFileResponse(videoFileId) } returns videoFileResponse
 
-                service.uploadVideo(1L, "video.mp4")
+                facade.uploadVideo(1L, "video.mp4")
 
                 Then("영상 파일이 할당된다") {
                     event.videoFileId shouldBe videoFileId
@@ -139,7 +130,7 @@ class EventServiceTest :
                 Then("CustomException이 발생한다") {
                     val exception =
                         shouldThrow<CustomException> {
-                            service.uploadVideo(999L, "video.mp4")
+                            facade.uploadVideo(999L, "video.mp4")
                         }
                     exception.code shouldBe SafersErrorCode.NOT_FOUND_EVENT
                 }
@@ -151,7 +142,7 @@ class EventServiceTest :
                 every { eventFileDownloadService.downloadAndInitiateUpload("/videos/", "video.mp4") } returns null
                 every { eventRepository.findByIdOrNull(1L) } returns event
 
-                service.uploadVideo(1L, "video.mp4")
+                facade.uploadVideo(1L, "video.mp4")
 
                 Then("파일 업로드가 수행되지 않는다") {
                     verify(exactly = 0) { fileService.finalizeUpload(any(), eq("events/1/")) }

--- a/apps/yongin-platform/src/main/kotlin/com/pluxity/yongin/attendance/controller/AttendanceController.kt
+++ b/apps/yongin-platform/src/main/kotlin/com/pluxity/yongin/attendance/controller/AttendanceController.kt
@@ -6,7 +6,7 @@ import com.pluxity.common.core.response.ErrorResponseBody
 import com.pluxity.common.core.response.PageResponse
 import com.pluxity.yongin.attendance.dto.AttendanceResponse
 import com.pluxity.yongin.attendance.dto.AttendanceUpdateRequest
-import com.pluxity.yongin.attendance.service.AttendanceService
+import com.pluxity.yongin.attendance.service.AttendanceFacade
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/attendances")
 @Tag(name = "Attendance Controller", description = "출역현황 관리 API")
 class AttendanceController(
-    private val service: AttendanceService,
+    private val service: AttendanceFacade,
 ) {
     @Operation(summary = "출역현황 전체 조회", description = "외부 API를 호출하여 데이터를 동기화한 후 출역현황을 조회합니다")
     @ApiResponses(

--- a/apps/yongin-platform/src/main/kotlin/com/pluxity/yongin/attendance/service/AttendanceFacade.kt
+++ b/apps/yongin-platform/src/main/kotlin/com/pluxity/yongin/attendance/service/AttendanceFacade.kt
@@ -1,0 +1,26 @@
+package com.pluxity.yongin.attendance.service
+
+import com.pluxity.common.core.dto.PageSearchRequest
+import com.pluxity.common.core.response.PageResponse
+import com.pluxity.yongin.attendance.client.AttendanceApiClient
+import com.pluxity.yongin.attendance.dto.AttendanceResponse
+import com.pluxity.yongin.attendance.dto.AttendanceUpdateRequest
+import org.springframework.stereotype.Component
+
+@Component
+class AttendanceFacade(
+    private val attendanceService: AttendanceService,
+    private val apiClient: AttendanceApiClient,
+) {
+    fun findAllWithSync(request: PageSearchRequest): PageResponse<AttendanceResponse> {
+        val externalData = apiClient.fetchAttendanceData()
+        return attendanceService.syncAndFindAll(externalData, request)
+    }
+
+    fun findLatest(): List<AttendanceResponse> = attendanceService.findLatest()
+
+    fun updateWorkContent(
+        id: Long,
+        request: AttendanceUpdateRequest,
+    ) = attendanceService.updateWorkContent(id, request)
+}

--- a/apps/yongin-platform/src/main/kotlin/com/pluxity/yongin/attendance/service/AttendanceService.kt
+++ b/apps/yongin-platform/src/main/kotlin/com/pluxity/yongin/attendance/service/AttendanceService.kt
@@ -5,7 +5,6 @@ import com.pluxity.common.core.exception.CustomException
 import com.pluxity.common.core.response.PageResponse
 import com.pluxity.common.core.response.toPageResponse
 import com.pluxity.common.core.utils.findPageNotNull
-import com.pluxity.yongin.attendance.client.AttendanceApiClient
 import com.pluxity.yongin.attendance.dto.AttendanceExternalData
 import com.pluxity.yongin.attendance.dto.AttendanceResponse
 import com.pluxity.yongin.attendance.dto.AttendanceUpdateRequest
@@ -17,38 +16,33 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDate
 
 @Service
+@Transactional(readOnly = true)
 class AttendanceService(
     private val repository: AttendanceRepository,
-    private val apiClient: AttendanceApiClient,
-    private val transactionTemplate: TransactionTemplate,
 ) {
-    fun findAllWithSync(request: PageSearchRequest): PageResponse<AttendanceResponse> {
-        // 외부 API 호출 — 트랜잭션 밖에서 수행
-        val externalData = apiClient.fetchAttendanceData()
+    @Transactional
+    fun syncAndFindAll(
+        externalData: List<AttendanceExternalData>,
+        request: PageSearchRequest,
+    ): PageResponse<AttendanceResponse> {
+        syncAttendanceData(externalData)
 
-        // DB 동기화 + 조회 — 트랜잭션 안에서 수행
-        return transactionTemplate.execute {
-            syncAttendanceData(externalData)
-
-            val pageable = PageRequest.of(request.page - 1, request.size)
-            val page =
-                repository.findPageNotNull(pageable) {
-                    select(entity(Attendance::class))
-                        .from(entity(Attendance::class))
-                        .orderBy(
-                            path(Attendance::attendanceDate).desc(),
-                            path(Attendance::id).asc(),
-                        )
-                }
-            page.toPageResponse { it.toResponse() }
-        }
+        val pageable = PageRequest.of(request.page - 1, request.size)
+        val page =
+            repository.findPageNotNull(pageable) {
+                select(entity(Attendance::class))
+                    .from(entity(Attendance::class))
+                    .orderBy(
+                        path(Attendance::attendanceDate).desc(),
+                        path(Attendance::id).asc(),
+                    )
+            }
+        return page.toPageResponse { it.toResponse() }
     }
 
-    @Transactional(readOnly = true)
     fun findLatest(): List<AttendanceResponse> = repository.findAllByLatestDate().map { it.toResponse() }
 
     @Transactional
@@ -61,17 +55,12 @@ class AttendanceService(
         if (externalData.isEmpty()) return
 
         val date = LocalDate.now()
-
-        // 외부 데이터의 deviceName 목록 추출
         val deviceNames = externalData.map { it.deviceName }
-
-        // 날짜+deviceName 조건으로 한 번에 조회 후 Map으로 변환
         val existingMap =
             repository
                 .findByAttendanceDateAndDeviceNameIn(date, deviceNames)
                 .associateBy { it.deviceName }
 
-        // 수정/신규 목록 생성
         val toSave =
             externalData.map { data ->
                 existingMap[data.deviceName]?.apply {
@@ -83,7 +72,6 @@ class AttendanceService(
                 )
             }
 
-        // 한 번에 저장
         repository.saveAll(toSave)
     }
 

--- a/apps/yongin-platform/src/test/kotlin/com/pluxity/yongin/attendance/service/AttendanceServiceTest.kt
+++ b/apps/yongin-platform/src/test/kotlin/com/pluxity/yongin/attendance/service/AttendanceServiceTest.kt
@@ -23,7 +23,6 @@ import io.mockk.verify
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDate
 
 class AttendanceServiceTest :
@@ -33,14 +32,8 @@ class AttendanceServiceTest :
 
         val repository: AttendanceRepository = mockk(relaxed = true)
         val apiClient: AttendanceApiClient = mockk()
-        val transactionTemplate: TransactionTemplate =
-            mockk {
-                every { execute<Any>(any()) } answers {
-                    val callback = firstArg<org.springframework.transaction.support.TransactionCallback<Any>>()
-                    callback.doInTransaction(mockk())
-                }
-            }
-        val service = AttendanceService(repository, apiClient, transactionTemplate)
+        val service = AttendanceService(repository)
+        val facade = AttendanceFacade(service, apiClient)
 
         Given("최신 출역현황 조회") {
 
@@ -128,7 +121,7 @@ class AttendanceServiceTest :
                     )
                 } returns PageImpl(savedEntities)
 
-                val result = service.findAllWithSync(request)
+                val result = facade.findAllWithSync(request)
 
                 Then("동기화 후 목록이 반환된다") {
                     result.content.size shouldBe 2
@@ -152,7 +145,7 @@ class AttendanceServiceTest :
                     )
                 } returns PageImpl(listOf(existingEntity))
 
-                service.findAllWithSync(request)
+                facade.findAllWithSync(request)
 
                 Then("기존 데이터가 수정된다") {
                     existingEntity.attendanceCount shouldBe 15
@@ -169,7 +162,7 @@ class AttendanceServiceTest :
                     )
                 } returns PageImpl(emptyList())
 
-                service.findAllWithSync(request)
+                facade.findAllWithSync(request)
 
                 Then("동기화가 수행되지 않는다") {
                     verify(exactly = 0) { repository.saveAll(any<List<Attendance>>()) }


### PR DESCRIPTION
- EventFacade, CctvFacade, WeatherFacade, AttendanceFacade 추가
- 외부 API 호출은 Facade에서, DB 작업은 Service의 @Transactional로 분리
- Service 클래스 레벨에 @Transactional(readOnly = true) 적용
- TransactionTemplate 의존성 전체 제거

## 요약
  

## 이슈 넘버 or 관련 링크
  

## 변경사항 🏗️  


<!-- 변경 사항에 대해서 기재 필요 -->
### Checklist 📋
## 코드 변경 사항   
- [ ] PR 설명에 변경 사항을 명확히 기재했습니다.  
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
