### PR TITLE
feat: NVR 녹화영상 재생 세션 삭제 API 추가

### DIFF
--- a/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/client/CctvApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/client/CctvApiClient.kt
@@ -6,11 +6,14 @@ import com.pluxity.safers.cctv.config.CctvErrorCode
 import com.pluxity.safers.cctv.dto.MediaServerPathItem
 import com.pluxity.safers.cctv.dto.MediaServerPathListResponse
 import com.pluxity.safers.cctv.dto.MediaServerPlaybackResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+
+private val log = KotlinLogging.logger {}
 
 @Component
 class CctvApiClient(
@@ -55,6 +58,25 @@ class CctvApiClient(
             .bodyToMono<MediaServerPlaybackResponse>()
             .block()
             ?: throw CustomException(CctvErrorCode.PLAYBACK_REQUEST_FAILED)
+    }
+
+    fun deletePlayback(
+        baseUrl: String,
+        siteId: Long,
+        nvrId: String,
+        pathName: String,
+    ) {
+        try {
+            val client = createClientForSite(baseUrl, siteId)
+            client
+                .delete()
+                .uri("/v3/nvr/$nvrId/playback/$pathName")
+                .retrieve()
+                .bodyToMono<Void>()
+                .block()
+        } catch (e: Exception) {
+            log.warn(e) { "Playback 세션 삭제 실패 - nvrId: $nvrId, pathName: $pathName" }
+        }
     }
 
     fun fetchPaths(

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/controller/CctvController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/controller/CctvController.kt
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -131,4 +132,39 @@ class CctvController(
         @PathVariable id: Long,
         @RequestBody @Valid request: CctvPlaybackRequest,
     ): ResponseEntity<DataResponseBody<CctvPlaybackResponse>> = ResponseEntity.ok(DataResponseBody(service.playback(id, request)))
+
+    @Operation(summary = "NVR 녹화영상 재생 세션 삭제", description = "생성된 NVR 녹화영상 재생 세션을 삭제합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "삭제 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "NVR 정보 누락 또는 미디어서버 URL 미설정",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "CCTV를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @DeleteMapping("/{id}/playback/{pathName}")
+    fun deletePlayback(
+        @PathVariable id: Long,
+        @PathVariable pathName: String,
+    ): ResponseEntity<Void> {
+        service.deletePlayback(id, pathName)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/service/CctvFacade.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/cctv/service/CctvFacade.kt
@@ -7,6 +7,7 @@ import com.pluxity.safers.cctv.dto.CctvPlaybackRequest
 import com.pluxity.safers.cctv.dto.CctvPlaybackResponse
 import com.pluxity.safers.cctv.dto.CctvResponse
 import com.pluxity.safers.cctv.dto.CctvUpdateRequest
+import com.pluxity.safers.cctv.entity.Cctv
 import com.pluxity.safers.site.repository.SiteRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
@@ -73,6 +74,27 @@ class CctvFacade(
         cctvId: Long,
         request: CctvPlaybackRequest,
     ): CctvPlaybackResponse {
+        val (baseUrl, siteId, nvrId, cctv) = resolvePlaybackInfo(cctvId)
+        val channel =
+            cctv.channel
+                ?: throw CustomException(CctvErrorCode.MISSING_NVR_INFO, cctvId)
+
+        val startTime = parseDateTime(request.startDate)
+        val endTime = parseDateTime(request.endDate)
+
+        val response = apiClient.requestPlayback(baseUrl, siteId, nvrId, channel, startTime, endTime)
+        return CctvPlaybackResponse(pathName = response.pathName)
+    }
+
+    fun deletePlayback(
+        cctvId: Long,
+        pathName: String,
+    ) {
+        val (baseUrl, siteId, nvrId) = resolvePlaybackInfo(cctvId)
+        apiClient.deletePlayback(baseUrl, siteId, nvrId, pathName.removePrefix("playback-"))
+    }
+
+    private fun resolvePlaybackInfo(cctvId: Long): PlaybackInfo {
         val cctv = cctvService.findByIdWithSite(cctvId)
         val site = cctv.site
 
@@ -82,16 +104,16 @@ class CctvFacade(
         val nvrId =
             cctv.nvrId
                 ?: throw CustomException(CctvErrorCode.MISSING_NVR_INFO, cctvId)
-        val channel =
-            cctv.channel
-                ?: throw CustomException(CctvErrorCode.MISSING_NVR_INFO, cctvId)
 
-        val startTime = parseDateTime(request.startDate)
-        val endTime = parseDateTime(request.endDate)
-
-        val response = apiClient.requestPlayback(baseUrl, site.requiredId, nvrId, channel, startTime, endTime)
-        return CctvPlaybackResponse(pathName = response.pathName)
+        return PlaybackInfo(baseUrl, site.requiredId, nvrId, cctv)
     }
+
+    private data class PlaybackInfo(
+        val baseUrl: String,
+        val siteId: Long,
+        val nvrId: String,
+        val cctv: Cctv,
+    )
 
     private fun parseDateTime(value: String): LocalDateTime =
         try {


### PR DESCRIPTION
- DELETE /cctvs/{id}/playback/{pathName} 엔드포인트 추가
- 미디어서버 DELETE 실패 시 에러 로그만 남기고 204 응답
- pathName에서 "playback-" 접두어 제거 후 미디어서버에 요청
- resolvePlaybackInfo() 추출로 playback 생성/삭제 간 검증 로직 중복 제거

## 요약
  

## 이슈 넘버 or 관련 링크
  

## 변경사항 🏗️  


<!-- 변경 사항에 대해서 기재 필요 -->
### Checklist 📋
## 코드 변경 사항   
- [ ] PR 설명에 변경 사항을 명확히 기재했습니다.  
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
