### PR TITLE
feat: Kafka consumer retry 전용 예외 도입 및 DLT 제거

### DIFF
--- a/apps/safers/src/main/kotlin/com/pluxity/safers/collect/config/KafkaProducerConfig.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/collect/config/KafkaProducerConfig.kt
@@ -4,7 +4,6 @@ import com.pluxity.safers.collect.dto.CctvVideoMessage
 import com.pluxity.safers.event.dto.EventCreateRequest
 import com.pluxity.safers.global.config.KafkaProperties
 import org.apache.kafka.clients.producer.ProducerConfig
-import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -30,16 +29,4 @@ class KafkaProducerConfig(
 
     @Bean
     fun videoKafkaTemplate(): KafkaTemplate<String, CctvVideoMessage> = KafkaTemplate(DefaultKafkaProducerFactory(producerProps()))
-
-    @Bean
-    fun dltKafkaTemplate(): KafkaTemplate<String, ByteArray> =
-        KafkaTemplate(
-            DefaultKafkaProducerFactory(
-                mapOf(
-                    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to kafkaProperties.bootstrapServers,
-                    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
-                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to ByteArraySerializer::class.java,
-                ),
-            ),
-        )
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/collect/config/KafkaTopicConfig.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/collect/config/KafkaTopicConfig.kt
@@ -21,9 +21,4 @@ class KafkaTopicConfig(
     @Bean
     fun plxCctvEventVideosTopic(): NewTopic = NewTopic(CctvEventCollector.TOPIC_VIDEOS, 1, 1.toShort())
 
-    @Bean
-    fun plxCctvEventsDltTopic(): NewTopic = NewTopic("${CctvEventCollector.TOPIC_EVENTS}.DLT", 1, 1.toShort())
-
-    @Bean
-    fun plxCctvEventVideosDltTopic(): NewTopic = NewTopic("${CctvEventCollector.TOPIC_VIDEOS}.DLT", 1, 1.toShort())
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/kafka/KafkaConsumerConfig.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/kafka/KafkaConsumerConfig.kt
@@ -11,8 +11,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
-import org.springframework.kafka.core.KafkaTemplate
-import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
 import org.springframework.kafka.support.serializer.JacksonJsonDeserializer
 import org.springframework.util.backoff.FixedBackOff
@@ -33,14 +31,15 @@ class KafkaConsumerConfig(
         )
 
     @Bean
-    fun kafkaErrorHandler(dltKafkaTemplate: KafkaTemplate<String, ByteArray>): DefaultErrorHandler {
-        val recoverer = DeadLetterPublishingRecoverer(dltKafkaTemplate)
-        return DefaultErrorHandler(recoverer, FixedBackOff(1000L, 3L)).apply {
+    fun kafkaErrorHandler(): DefaultErrorHandler =
+        DefaultErrorHandler({ record, ex ->
+            logger.error(ex) { "Kafka 소비 최종 실패 (DLT 전송 생략): topic=${record.topic()}, key=${record.key()}" }
+        }, FixedBackOff(1000L, 3L)).apply {
+            addRetryableExceptions(RetryableException::class.java)
             setRetryListeners({ record, ex, deliveryAttempt ->
                 logger.warn(ex) { "Kafka 소비 재시도 (${deliveryAttempt}회): topic=${record.topic()}, key=${record.key()}" }
             })
         }
-    }
 
     @Bean
     fun cctvEventListenerFactory(

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/kafka/RetryableException.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/kafka/RetryableException.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safers.event.kafka
+
+class RetryableException(message: String) : RuntimeException(message)

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventService.kt
@@ -7,6 +7,7 @@ import com.pluxity.common.core.response.toPageResponse
 import com.pluxity.common.file.extensions.getFileMapByIds
 import com.pluxity.common.file.service.FileService
 import com.pluxity.safers.event.dto.EventCreateRequest
+import com.pluxity.safers.event.kafka.RetryableException
 import com.pluxity.safers.event.dto.EventResponse
 import com.pluxity.safers.event.dto.toResponse
 import com.pluxity.safers.event.entity.Event
@@ -72,7 +73,7 @@ class EventService(
     ) {
         val event =
             eventRepository.findByEventId(eventId)
-                ?: throw CustomException(SafersErrorCode.NOT_FOUND_EVENT, eventId)
+                ?: throw RetryableException("이벤트 미생성 상태, 재시도 필요: eventId=$eventId")
 
         event.assignVideoFile(videoFileId)
 


### PR DESCRIPTION
## Summary
- `RetryableException` 전용 클래스를 추가하여 Kafka retry 대상을 화이트리스트 방식으로 명시적 제어
- 영상 소비 시 이벤트 미존재(race condition) 상황에서 1초 간격 3회 retry 후 skip
- 불필요한 DLT 토픽 및 dltKafkaTemplate 제거로 인프라 단순화

## Test plan
- [ ] 이벤트 생성 후 영상 메시지가 정상 소비되는지 확인
- [ ] 영상 메시지가 이벤트보다 먼저 도착 시 retry 후 정상 처리 확인
- [ ] 3회 retry 후에도 실패 시 로깅 후 다음 메시지로 넘어가는지 확인