### PR TITLE
feat: A2UI 날씨 응답에 현장 이름 포함

### DIFF
--- a/apps/safers/src/main/kotlin/com/pluxity/safers/chat/dto/ActionFilter.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/chat/dto/ActionFilter.kt
@@ -58,7 +58,7 @@ sealed class ActionFilter {
 
     @JsonTypeName("WEATHER")
     data class Weather(
-        override val siteId: Long? = null,
+        override val siteId: Long,
     ) : ActionFilter()
 
     @JsonTypeName("SITE")

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/chat/dto/ChatWeatherResponse.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/chat/dto/ChatWeatherResponse.kt
@@ -1,0 +1,8 @@
+package com.pluxity.safers.chat.dto
+
+import com.pluxity.safers.weather.dto.WeatherTimeGroupResponse
+
+data class ChatWeatherResponse(
+    val siteName: String,
+    val forecasts: List<WeatherTimeGroupResponse>,
+)

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/chat/service/ChatActionExecutor.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/chat/service/ChatActionExecutor.kt
@@ -6,6 +6,7 @@ import com.pluxity.safers.cctv.service.CctvService
 import com.pluxity.safers.chat.dto.ActionFilter
 import com.pluxity.safers.chat.dto.ActionResult
 import com.pluxity.safers.chat.dto.ChatActionRequest
+import com.pluxity.safers.chat.dto.ChatWeatherResponse
 import com.pluxity.safers.chat.dto.QueryAction
 import com.pluxity.safers.chat.dto.QueryContext
 import com.pluxity.safers.chat.dto.QueryTarget
@@ -14,6 +15,7 @@ import com.pluxity.safers.event.service.EventService
 import com.pluxity.safers.global.constant.SafersErrorCode
 import com.pluxity.safers.site.dto.toResponse
 import com.pluxity.safers.site.repository.SiteRepository
+import com.pluxity.safers.site.service.SiteService
 import com.pluxity.safers.weather.service.WeatherService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
@@ -30,6 +32,7 @@ class ChatActionExecutor(
     private val eventService: EventService,
     private val cctvService: CctvService,
     private val weatherService: WeatherService,
+    private val siteService: SiteService,
     private val siteRepository: SiteRepository,
 ) {
     companion object {
@@ -90,14 +93,16 @@ class ChatActionExecutor(
 
     private fun executeWeatherQuery(action: QueryAction): ActionResult {
         val filter = action.filters as ActionFilter.Weather
-        if (filter.siteId != null) {
-            return ActionResult.SingleResult(data = weatherService.findDashboard(filter.siteId))
-        }
+        val siteName =
+            siteService.findAllSites().find { it.id == filter.siteId }?.name
+                ?: throw CustomException(SafersErrorCode.NOT_FOUND_SITE, filter.siteId)
+
         return ActionResult.SingleResult(
             data =
-                siteRepository.findAll().associate { site ->
-                    site.name to weatherService.findDashboard(site.requiredId)
-                },
+                ChatWeatherResponse(
+                    siteName = siteName,
+                    forecasts = weatherService.findDashboard(filter.siteId),
+                ),
         )
     }
 

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/llm/ChatLlmClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/llm/ChatLlmClient.kt
@@ -128,7 +128,8 @@ class ChatLlmClient(
                 )
             QueryTarget.WEATHER ->
                 ActionFilter.Weather(
-                    siteId = filtersNode?.get("siteId")?.asLong(),
+                    siteId = filtersNode?.get("siteId")?.asLong()
+                        ?: throw IllegalArgumentException("weather action은 siteId가 필수입니다"),
                 )
             QueryTarget.SITE ->
                 ActionFilter.Site(

--- a/apps/safers/src/main/resources/catalogs/domain-catalog.json
+++ b/apps/safers/src/main/resources/catalogs/domain-catalog.json
@@ -25,12 +25,13 @@
       "required": ["name", "streamName"]
     },
     "WeatherCard": {
-      "description": "날씨 카드. data path로 날씨 데이터 참조",
+      "description": "날씨 카드. siteName은 현장 이름, data는 날씨 예보 경로",
       "properties": {
-        "data": { "$ref": "#/$defs/PathBinding", "description": "날씨 데이터 경로" },
+        "siteName": { "$ref": "#/$defs/PathBinding", "description": "현장 이름" },
+        "data": { "$ref": "#/$defs/PathBinding", "description": "날씨 예보(forecasts) 데이터 경로" },
         "size": { "type": "string", "enum": ["sm", "md", "lg"], "default": "md" }
       },
-      "required": ["data"]
+      "required": ["siteName", "data"]
     },
     "EventAlertCard": {
       "description": "이벤트 알림 카드 (List 안에서 path 바인딩 사용)",

--- a/apps/safers/src/main/resources/prompts/chat-intent-system.txt
+++ b/apps/safers/src/main/resources/prompts/chat-intent-system.txt
@@ -44,7 +44,7 @@ IMPORTANT: "~도"(also), "추가해줘"(add), "빼줘"(remove) 같은 표현은 
   - cctv: CCTV 카메라
     - filters: { name?: string, siteId?: number }
   - weather: 날씨
-    - filters: { siteId?: number }
+    - filters: { siteId: number }   // siteId 필수
   - site: 현장 정보
     - filters: { siteId?: number }
 - IMPORTANT: page와 size는 filters 안이 아니라 action 최상위에 위치해야 합니다.

--- a/apps/safers/src/main/resources/prompts/chat-system.txt
+++ b/apps/safers/src/main/resources/prompts/chat-system.txt
@@ -71,8 +71,9 @@ Props: name (path), streamName (path), variant ("live"|"alert"|"offline"), size 
 ### WeatherCard — weather overview
 Props: siteName (path — 현장 이름), data (path — 날씨 예보 데이터 경로), size ("sm"|"md"|"lg")
 - dataModel 구조: `{siteName: string, forecasts: WeatherTimeGroupResponse[]}` (각 weather action 키 아래)
-- siteName: {"path": "/weather/siteName"} — 현장 이름
-- data: {"path": "/weather/forecasts"} — 날씨 예보 배열
+- path는 **실제 action id**를 그대로 사용한다. 액션 id가 `weather`면 `/weather/...`, `weather-15`면 `/weather-15/...`
+- siteName: {"path": "/weather/siteName"} 또는 {"path": "/weather-15/siteName"} — 현장 이름
+- data: {"path": "/weather/forecasts"} 또는 {"path": "/weather-15/forecasts"} — 날씨 예보 배열
 
 ### AgentMessageCard — AI agent insight message
 Props: message (string) — 리터럴 텍스트 사용

--- a/apps/safers/src/main/resources/prompts/chat-system.txt
+++ b/apps/safers/src/main/resources/prompts/chat-system.txt
@@ -69,8 +69,10 @@ Props: cameras (path — CCTV 배열 경로), siteId (number), columns (number, 
 Props: name (path), streamName (path), variant ("live"|"alert"|"offline"), size ("sm"|"md"|"lg")
 
 ### WeatherCard — weather overview
-Props: data (path — 날씨 데이터 경로), size ("sm"|"md"|"lg")
-- data: {"path": "/weather"} — updateDataModel의 날씨 데이터 참조
+Props: siteName (path — 현장 이름), data (path — 날씨 예보 데이터 경로), size ("sm"|"md"|"lg")
+- dataModel 구조: `{siteName: string, forecasts: WeatherTimeGroupResponse[]}` (각 weather action 키 아래)
+- siteName: {"path": "/weather/siteName"} — 현장 이름
+- data: {"path": "/weather/forecasts"} — 날씨 예보 배열
 
 ### AgentMessageCard — AI agent insight message
 Props: message (string) — 리터럴 텍스트 사용
@@ -160,7 +162,7 @@ FlexRow 자식에 weight를 설정하여 컨텐츠 종류와 데이터 양에 �
 Given: 이벤트 3건 (events), CCTV 16대 (cctvs), 날씨 있음 (weather), 현장 siteId=15
 
 {"surfaceUpdate":{"surfaceId":"main","components":[
-  {"id":"weather","component":{"WeatherCard":{"data":{"path":"/weather"},"size":"md"}}},
+  {"id":"weather","component":{"WeatherCard":{"siteName":{"path":"/weather/siteName"},"data":{"path":"/weather/forecasts"},"size":"md"}}},
   {"id":"cctv","component":{"CCTVViewer":{"cameras":{"path":"/cctvs"},"siteId":15,"columns":2,"pageSize":4,"size":"md"}}},
   {"id":"eventCard","component":{"EventAlertCard":{"variant":{"path":"type"},"title":{"path":"name"},"location":{"path":"path"},"time":{"path":"timestamp"},"size":"md","confidence":{"path":"confidence"}}}},
   {"id":"eventList","component":{"List":{"children":{"componentId":"eventCard","path":"/events/content"}}}},


### PR DESCRIPTION
## Summary
- A2UI 채팅 응답의 날씨 dataModel을 `{siteName, forecasts}` 객체로 래핑하여 `WeatherCard` 컴포넌트가 현장 이름을 표시 가능하도록 변경
- `ActionFilter.Weather.siteId`를 non-null로 강제하고 파싱 단계에서 검증
- site 조회 최적화: `SiteService.findAllSites()` 캐시(`@Cacheable("sites")`) 활용

## Changes
| 파일 | 변경 |
|---|---|
| `chat/dto/ChatWeatherResponse.kt` (신규) | `siteName`, `forecasts` 2필드 DTO |
| `chat/dto/ActionFilter.kt` | `Weather.siteId: Long? → Long` |
| `chat/service/ChatActionExecutor.kt` | `SiteService` 주입, weather 쿼리 단순화 (분기 제거) |
| `llm/ChatLlmClient.kt` | weather action 파싱 시 `siteId` 필수 검증 |
| `catalogs/domain-catalog.json` | `WeatherCard`에 `siteName` prop 추가 |
| `prompts/chat-system.txt` | WeatherCard 설명 + dataModel 구조 anchor + Example 갱신 |
| `prompts/chat-intent-system.txt` | weather filter `siteId` 필수 표기 |

## 응답 구조 변경

Before:
\`\`\`json
{ "weather-17": [ {fcstDate, fcstTime, items}, ... ] }
\`\`\`

After:
\`\`\`json
{ "weather-17": { "siteName": "김포 풍무B5", "forecasts": [ {fcstDate, fcstTime, items}, ... ] } }
\`\`\`

컴포넌트 바인딩:
\`\`\`json
{"WeatherCard": {
  "siteName": {"path":"/weather-17/siteName"},
  "data":     {"path":"/weather-17/forecasts"},
  "size": "md"
}}
\`\`\`

## Test plan
- [ ] 단일 현장 날씨 조회: `"김포 날씨"` → WeatherCard에 현장명 렌더링 확인
- [ ] 멀티 현장 날씨 조회: `"전체 날씨"` → 각 `weather-{siteId}` 키 아래 siteName 포함 확인
- [ ] 잘못된 siteId → `NOT_FOUND_SITE` 에러 graceful 처리 확인
- [ ] `/chat/action` 페이지 재조회 시 path binding 정상 동작 확인
- [ ] 프론트 WeatherCard 컴포넌트 siteName prop 수신 확인 (프론트 별도 작업)

## Out of Scope
- 프론트 `WeatherCard` 컴포넌트의 siteName 렌더 구현 (프론트 레포)
- `executeSiteQuery`의 `siteRepository` → `SiteService` 전환 (별도 PR)
- chat 모듈 테스트 추가 (별도 PR)
- A2UI v0.9 프로토콜 마이그레이션 (별도 논의)