### PR TITLE
fix: 기상청 API 커넥션 안정화 및 비정상 응답 처리

### DIFF
--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/controller/ConfigurationController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/controller/ConfigurationController.kt
@@ -52,7 +52,7 @@ class ConfigurationController(
         @RequestBody
         @Valid
         request: ConfigurationRequest,
-    ): ResponseEntity<Long> = ResponseEntity.ok(configurationService.create(request))
+    ): ResponseEntity<String> = ResponseEntity.ok(configurationService.create(request))
 
     @Operation(summary = "설정 목록 조회", description = "모든 설정 목록을 페이지네이션으로 조회합니다")
     @ApiResponses(
@@ -71,7 +71,7 @@ class ConfigurationController(
     ): ResponseEntity<DataResponseBody<PageResponse<ConfigurationResponse>>> =
         ResponseEntity.ok(DataResponseBody(configurationService.findAll(PageSearchRequest(page, size))))
 
-    @Operation(summary = "설정 상세 조회", description = "ID로 특정 설정의 상세 정보를 조회합니다")
+    @Operation(summary = "설정 상세 조회", description = "키로 특정 설정의 상세 정보를 조회합니다")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "설정 조회 성공"),
@@ -82,12 +82,12 @@ class ConfigurationController(
             ),
         ],
     )
-    @GetMapping("/{id}")
+    @GetMapping("/{key}")
     fun getConfiguration(
         @PathVariable
-        @Parameter(description = "설정 ID", required = true)
-        id: Long,
-    ): ResponseEntity<DataResponseBody<ConfigurationResponse>> = ResponseEntity.ok(DataResponseBody(configurationService.findById(id)))
+        @Parameter(description = "설정 키", required = true)
+        key: String,
+    ): ResponseEntity<DataResponseBody<ConfigurationResponse>> = ResponseEntity.ok(DataResponseBody(configurationService.findByKey(key)))
 
     @Operation(summary = "설정 수정", description = "설정 값을 수정합니다. 키는 불변입니다.")
     @ApiResponses(
@@ -100,17 +100,17 @@ class ConfigurationController(
             ),
         ],
     )
-    @PutMapping("/{id}")
+    @PutMapping("/{key}")
     fun updateConfiguration(
         @PathVariable
-        @Parameter(description = "설정 ID", required = true)
-        id: Long,
+        @Parameter(description = "설정 키", required = true)
+        key: String,
         @Parameter(description = "설정 수정 정보", required = true)
         @RequestBody
         @Valid
         request: ConfigurationUpdateRequest,
     ): ResponseEntity<Void> {
-        configurationService.update(id, request)
+        configurationService.update(key, request)
         return ResponseEntity.noContent().build()
     }
 
@@ -125,13 +125,13 @@ class ConfigurationController(
             ),
         ],
     )
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{key}")
     fun deleteConfiguration(
         @PathVariable
-        @Parameter(description = "설정 ID", required = true)
-        id: Long,
+        @Parameter(description = "설정 키", required = true)
+        key: String,
     ): ResponseEntity<Void> {
-        configurationService.delete(id)
+        configurationService.delete(key)
         return ResponseEntity.noContent().build()
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/controller/ConfigurationController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/controller/ConfigurationController.kt
@@ -1,0 +1,137 @@
+package com.pluxity.safers.configuration.controller
+
+import com.pluxity.common.core.annotation.ResponseCreated
+import com.pluxity.common.core.dto.PageSearchRequest
+import com.pluxity.common.core.response.DataResponseBody
+import com.pluxity.common.core.response.ErrorResponseBody
+import com.pluxity.common.core.response.PageResponse
+import com.pluxity.safers.configuration.dto.ConfigurationRequest
+import com.pluxity.safers.configuration.dto.ConfigurationResponse
+import com.pluxity.safers.configuration.dto.ConfigurationUpdateRequest
+import com.pluxity.safers.configuration.service.ConfigurationService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/configurations")
+@Tag(name = "Configuration Controller", description = "설정 관리 API")
+class ConfigurationController(
+    private val configurationService: ConfigurationService,
+) {
+    @Operation(summary = "설정 등록", description = "새로운 설정을 등록합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "설정 등록 성공"),
+            ApiResponse(
+                responseCode = "409",
+                description = "설정 키 중복",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PostMapping
+    @ResponseCreated(path = "/configurations/{id}")
+    fun createConfiguration(
+        @Parameter(description = "설정 등록 정보", required = true)
+        @RequestBody
+        @Valid
+        request: ConfigurationRequest,
+    ): ResponseEntity<Long> = ResponseEntity.ok(configurationService.create(request))
+
+    @Operation(summary = "설정 목록 조회", description = "모든 설정 목록을 페이지네이션으로 조회합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "목록 조회 성공"),
+        ],
+    )
+    @GetMapping
+    fun getAllConfigurations(
+        @Parameter(description = "조회 페이지번호", example = "1")
+        @RequestParam("page")
+        page: Int = 1,
+        @Parameter(description = "페이지당 개수", example = "9999")
+        @RequestParam("size")
+        size: Int = 9999,
+    ): ResponseEntity<DataResponseBody<PageResponse<ConfigurationResponse>>> =
+        ResponseEntity.ok(DataResponseBody(configurationService.findAll(PageSearchRequest(page, size))))
+
+    @Operation(summary = "설정 상세 조회", description = "ID로 특정 설정의 상세 정보를 조회합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "설정 조회 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "설정을 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @GetMapping("/{id}")
+    fun getConfiguration(
+        @PathVariable
+        @Parameter(description = "설정 ID", required = true)
+        id: Long,
+    ): ResponseEntity<DataResponseBody<ConfigurationResponse>> = ResponseEntity.ok(DataResponseBody(configurationService.findById(id)))
+
+    @Operation(summary = "설정 수정", description = "설정 값을 수정합니다. 키는 불변입니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "설정 수정 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "설정을 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PutMapping("/{id}")
+    fun updateConfiguration(
+        @PathVariable
+        @Parameter(description = "설정 ID", required = true)
+        id: Long,
+        @Parameter(description = "설정 수정 정보", required = true)
+        @RequestBody
+        @Valid
+        request: ConfigurationUpdateRequest,
+    ): ResponseEntity<Void> {
+        configurationService.update(id, request)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "설정 삭제", description = "설정을 삭제합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "설정 삭제 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "설정을 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @DeleteMapping("/{id}")
+    fun deleteConfiguration(
+        @PathVariable
+        @Parameter(description = "설정 ID", required = true)
+        id: Long,
+    ): ResponseEntity<Void> {
+        configurationService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationRequest.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationRequest.kt
@@ -2,13 +2,16 @@ package com.pluxity.safers.configuration.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 
 @Schema(description = "설정 등록 요청")
 data class ConfigurationRequest(
     @field:NotBlank(message = "설정 키는 필수입니다.")
+    @field:Size(max = 255, message = "설정 키는 255자 이하여야 합니다.")
     @field:Schema(description = "설정 키", example = "WEATHER_API")
     val key: String,
     @field:NotBlank(message = "설정 값은 필수입니다.")
+    @field:Size(max = 255, message = "설정 값은 255자 이하여야 합니다.")
     @field:Schema(description = "설정 값", example = "your-api-key")
     val value: String,
 )
@@ -16,6 +19,7 @@ data class ConfigurationRequest(
 @Schema(description = "설정 수정 요청")
 data class ConfigurationUpdateRequest(
     @field:NotBlank(message = "설정 값은 필수입니다.")
+    @field:Size(max = 255, message = "설정 값은 255자 이하여야 합니다.")
     @field:Schema(description = "설정 값", example = "your-api-key")
     val value: String,
 )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationRequest.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationRequest.kt
@@ -1,0 +1,21 @@
+package com.pluxity.safers.configuration.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "설정 등록 요청")
+data class ConfigurationRequest(
+    @field:NotBlank(message = "설정 키는 필수입니다.")
+    @field:Schema(description = "설정 키", example = "WEATHER_API")
+    val key: String,
+    @field:NotBlank(message = "설정 값은 필수입니다.")
+    @field:Schema(description = "설정 값", example = "your-api-key")
+    val value: String,
+)
+
+@Schema(description = "설정 수정 요청")
+data class ConfigurationUpdateRequest(
+    @field:NotBlank(message = "설정 값은 필수입니다.")
+    @field:Schema(description = "설정 값", example = "your-api-key")
+    val value: String,
+)

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationResponse.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationResponse.kt
@@ -8,8 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "설정 응답")
 data class ConfigurationResponse(
-    @field:Schema(description = "설정 ID")
-    val id: Long,
     @field:Schema(description = "설정 키")
     val key: String,
     @field:Schema(description = "설정 값")
@@ -20,7 +18,6 @@ data class ConfigurationResponse(
 
 fun Configuration.toResponse(): ConfigurationResponse =
     ConfigurationResponse(
-        id = requiredId,
         key = key,
         value = value,
         baseResponse = toBaseResponse(),

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationResponse.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/dto/ConfigurationResponse.kt
@@ -1,0 +1,27 @@
+package com.pluxity.safers.configuration.dto
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.pluxity.common.core.response.BaseResponse
+import com.pluxity.common.core.response.toBaseResponse
+import com.pluxity.safers.configuration.entity.Configuration
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "설정 응답")
+data class ConfigurationResponse(
+    @field:Schema(description = "설정 ID")
+    val id: Long,
+    @field:Schema(description = "설정 키")
+    val key: String,
+    @field:Schema(description = "설정 값")
+    val value: String,
+    @field:JsonUnwrapped
+    val baseResponse: BaseResponse,
+)
+
+fun Configuration.toResponse(): ConfigurationResponse =
+    ConfigurationResponse(
+        id = requiredId,
+        key = key,
+        value = value,
+        baseResponse = toBaseResponse(),
+    )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/entity/Configuration.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/entity/Configuration.kt
@@ -12,4 +12,8 @@ class Configuration(
     val key: String,
     @Column(name = "config_value", nullable = false)
     var value: String,
-) : IdentityIdEntity()
+) : IdentityIdEntity() {
+    fun update(value: String) {
+        this.value = value
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -11,19 +11,16 @@ import com.pluxity.safers.configuration.dto.toResponse
 import com.pluxity.safers.configuration.entity.Configuration
 import com.pluxity.safers.configuration.repository.ConfigurationRepository
 import com.pluxity.safers.global.constant.SafersErrorCode
-import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 
 @Service
 @Transactional(readOnly = true)
 class ConfigurationService(
     private val configurationRepository: ConfigurationRepository,
-    private val cacheManager: CacheManager,
 ) {
     companion object {
         const val CONFIGURATIONS_CACHE = "configurations"
@@ -33,13 +30,12 @@ class ConfigurationService(
     fun findValue(key: String): String? = configurationRepository.findByKey(key)?.value
 
     @Transactional
+    @CacheEvict(value = [CONFIGURATIONS_CACHE], key = "#request.key")
     fun create(request: ConfigurationRequest): String {
         if (configurationRepository.findByKey(request.key) != null) {
             throw CustomException(SafersErrorCode.DUPLICATE_CONFIGURATION, request.key)
         }
-        val saved = configurationRepository.save(Configuration(key = request.key, value = request.value))
-        evictCache(saved.key)
-        return saved.key
+        return configurationRepository.save(Configuration(key = request.key, value = request.value)).key
     }
 
     fun findAll(request: PageSearchRequest): PageResponse<ConfigurationResponse> {
@@ -50,37 +46,21 @@ class ConfigurationService(
     fun findByKey(key: String): ConfigurationResponse = getConfigurationByKey(key).toResponse()
 
     @Transactional
+    @CacheEvict(value = [CONFIGURATIONS_CACHE], key = "#key")
     fun update(
         key: String,
         request: ConfigurationUpdateRequest,
     ) {
-        val configuration = getConfigurationByKey(key)
-        configuration.update(request.value)
-        evictCache(key)
+        getConfigurationByKey(key).update(request.value)
     }
 
     @Transactional
+    @CacheEvict(value = [CONFIGURATIONS_CACHE], key = "#key")
     fun delete(key: String) {
-        val configuration = getConfigurationByKey(key)
-        configurationRepository.delete(configuration)
-        evictCache(key)
+        configurationRepository.delete(getConfigurationByKey(key))
     }
 
     private fun getConfigurationByKey(key: String): Configuration =
         configurationRepository.findByKey(key)
             ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, key)
-
-    private fun evictCache(key: String) {
-        if (TransactionSynchronizationManager.isSynchronizationActive()) {
-            TransactionSynchronizationManager.registerSynchronization(
-                object : TransactionSynchronization {
-                    override fun afterCommit() {
-                        cacheManager.getCache(CONFIGURATIONS_CACHE)?.evict(key)
-                    }
-                },
-            )
-        } else {
-            cacheManager.getCache(CONFIGURATIONS_CACHE)?.evict(key)
-        }
-    }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -8,10 +8,13 @@ import org.springframework.stereotype.Service
 class ConfigurationService(
     private val configurationRepository: ConfigurationRepository,
 ) {
-    @Cacheable(value = [CACHE_NAME], unless = "#result == null")
     fun findValue(key: String): String? = configurationRepository.findByKey(key)?.value
 
+    @Cacheable(value = [WEATHER_API_KEY_CACHE], unless = "#result == null")
+    fun findWeatherApiKey(): String? = configurationRepository.findByKey(WEATHER_API_KEY)?.value
+
     companion object {
-        const val CACHE_NAME = "configurations"
+        const val WEATHER_API_KEY_CACHE = "weather-api-key"
+        private const val WEATHER_API_KEY = "WEATHER_API"
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -8,13 +8,10 @@ import org.springframework.stereotype.Service
 class ConfigurationService(
     private val configurationRepository: ConfigurationRepository,
 ) {
+    @Cacheable(value = [CONFIGURATIONS_CACHE], key = "#key", unless = "#result == null")
     fun findValue(key: String): String? = configurationRepository.findByKey(key)?.value
 
-    @Cacheable(value = [WEATHER_API_KEY_CACHE], unless = "#result == null")
-    fun findWeatherApiKey(): String? = configurationRepository.findByKey(WEATHER_API_KEY)?.value
-
     companion object {
-        const val WEATHER_API_KEY_CACHE = "weather-api-key"
-        private const val WEATHER_API_KEY = "WEATHER_API"
+        const val CONFIGURATIONS_CACHE = "configurations"
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -1,17 +1,75 @@
 package com.pluxity.safers.configuration.service
 
+import com.pluxity.common.core.dto.PageSearchRequest
+import com.pluxity.common.core.exception.CustomException
+import com.pluxity.common.core.response.PageResponse
+import com.pluxity.common.core.response.toPageResponse
+import com.pluxity.safers.configuration.dto.ConfigurationRequest
+import com.pluxity.safers.configuration.dto.ConfigurationResponse
+import com.pluxity.safers.configuration.dto.ConfigurationUpdateRequest
+import com.pluxity.safers.configuration.dto.toResponse
+import com.pluxity.safers.configuration.entity.Configuration
 import com.pluxity.safers.configuration.repository.ConfigurationRepository
+import com.pluxity.safers.global.constant.SafersErrorCode
+import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class ConfigurationService(
     private val configurationRepository: ConfigurationRepository,
+    private val cacheManager: CacheManager,
 ) {
+    companion object {
+        const val CONFIGURATIONS_CACHE = "configurations"
+    }
+
     @Cacheable(value = [CONFIGURATIONS_CACHE], key = "#key", unless = "#result == null")
     fun findValue(key: String): String? = configurationRepository.findByKey(key)?.value
 
-    companion object {
-        const val CONFIGURATIONS_CACHE = "configurations"
+    @Transactional
+    fun create(request: ConfigurationRequest): Long {
+        if (configurationRepository.findByKey(request.key) != null) {
+            throw CustomException(SafersErrorCode.DUPLICATE_CONFIGURATION, request.key)
+        }
+        val saved = configurationRepository.save(Configuration(key = request.key, value = request.value))
+        evictCache(saved.key)
+        return saved.requiredId
+    }
+
+    fun findAll(request: PageSearchRequest): PageResponse<ConfigurationResponse> {
+        val pageable = PageRequest.of(request.page - 1, request.size)
+        return configurationRepository.findAll(pageable).toPageResponse { it.toResponse() }
+    }
+
+    fun findById(id: Long): ConfigurationResponse = getConfigurationById(id).toResponse()
+
+    @Transactional
+    fun update(
+        id: Long,
+        request: ConfigurationUpdateRequest,
+    ) {
+        val configuration = getConfigurationById(id)
+        configuration.update(request.value)
+        evictCache(configuration.key)
+    }
+
+    @Transactional
+    fun delete(id: Long) {
+        val configuration = getConfigurationById(id)
+        configurationRepository.delete(configuration)
+        evictCache(configuration.key)
+    }
+
+    private fun getConfigurationById(id: Long): Configuration =
+        configurationRepository.findByIdOrNull(id)
+            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID, id)
+
+    private fun evictCache(key: String) {
+        cacheManager.getCache(CONFIGURATIONS_CACHE)?.evict(key)
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -1,0 +1,17 @@
+package com.pluxity.safers.configuration.service
+
+import com.pluxity.safers.configuration.repository.ConfigurationRepository
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+
+@Service
+class ConfigurationService(
+    private val configurationRepository: ConfigurationRepository,
+) {
+    @Cacheable(value = [CACHE_NAME], unless = "#result == null")
+    fun findValue(key: String): String? = configurationRepository.findByKey(key)?.value
+
+    companion object {
+        const val CACHE_NAME = "configurations"
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -14,7 +14,6 @@ import com.pluxity.safers.global.constant.SafersErrorCode
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
@@ -34,13 +33,13 @@ class ConfigurationService(
     fun findValue(key: String): String? = configurationRepository.findByKey(key)?.value
 
     @Transactional
-    fun create(request: ConfigurationRequest): Long {
+    fun create(request: ConfigurationRequest): String {
         if (configurationRepository.findByKey(request.key) != null) {
             throw CustomException(SafersErrorCode.DUPLICATE_CONFIGURATION, request.key)
         }
         val saved = configurationRepository.save(Configuration(key = request.key, value = request.value))
         evictCache(saved.key)
-        return saved.requiredId
+        return saved.key
     }
 
     fun findAll(request: PageSearchRequest): PageResponse<ConfigurationResponse> {
@@ -48,28 +47,28 @@ class ConfigurationService(
         return configurationRepository.findAll(pageable).toPageResponse { it.toResponse() }
     }
 
-    fun findById(id: Long): ConfigurationResponse = getConfigurationById(id).toResponse()
+    fun findByKey(key: String): ConfigurationResponse = getConfigurationByKey(key).toResponse()
 
     @Transactional
     fun update(
-        id: Long,
+        key: String,
         request: ConfigurationUpdateRequest,
     ) {
-        val configuration = getConfigurationById(id)
+        val configuration = getConfigurationByKey(key)
         configuration.update(request.value)
-        evictCache(configuration.key)
+        evictCache(key)
     }
 
     @Transactional
-    fun delete(id: Long) {
-        val configuration = getConfigurationById(id)
+    fun delete(key: String) {
+        val configuration = getConfigurationByKey(key)
         configurationRepository.delete(configuration)
-        evictCache(configuration.key)
+        evictCache(key)
     }
 
-    private fun getConfigurationById(id: Long): Configuration =
-        configurationRepository.findByIdOrNull(id)
-            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID, id)
+    private fun getConfigurationByKey(key: String): Configuration =
+        configurationRepository.findByKey(key)
+            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, key)
 
     private fun evictCache(key: String) {
         if (TransactionSynchronizationManager.isSynchronizationActive()) {

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/configuration/service/ConfigurationService.kt
@@ -17,6 +17,8 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 
 @Service
 @Transactional(readOnly = true)
@@ -70,6 +72,16 @@ class ConfigurationService(
             ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID, id)
 
     private fun evictCache(key: String) {
-        cacheManager.getCache(CONFIGURATIONS_CACHE)?.evict(key)
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                object : TransactionSynchronization {
+                    override fun afterCommit() {
+                        cacheManager.getCache(CONFIGURATIONS_CACHE)?.evict(key)
+                    }
+                },
+            )
+        } else {
+            cacheManager.getCache(CONFIGURATIONS_CACHE)?.evict(key)
+        }
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/config/CacheConfig.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/config/CacheConfig.kt
@@ -18,6 +18,7 @@ class CacheConfig {
     fun cacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager =
         RedisCacheManager
             .builder(connectionFactory)
+            .transactionAware()
             .cacheDefaults(
                 RedisCacheConfiguration
                     .defaultCacheConfig()

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/config/SafersApiConfigurer.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/config/SafersApiConfigurer.kt
@@ -26,4 +26,7 @@ class SafersApiConfigurer : ApiConfigurer {
 
     @Bean
     fun collectApi(): GroupedOpenApi = apiGroup("8. 수집", "/collect/**")
+
+    @Bean
+    fun configurationApi(): GroupedOpenApi = apiGroup("9. 설정", "/configurations/**")
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/constant/SafersErrorCode.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/constant/SafersErrorCode.kt
@@ -10,6 +10,8 @@ enum class SafersErrorCode(
     NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "ID가 %s인 이벤트를 찾을 수 없습니다."),
     NOT_FOUND_SITE(HttpStatus.NOT_FOUND, "ID가 %s인 현장을 찾을 수 없습니다."),
     NOT_FOUND_CONFIGURATION(HttpStatus.NOT_FOUND, "키가 %s인 설정을 찾을 수 없습니다."),
+    NOT_FOUND_CONFIGURATION_BY_ID(HttpStatus.NOT_FOUND, "ID가 %s인 설정을 찾을 수 없습니다."),
+    DUPLICATE_CONFIGURATION(HttpStatus.CONFLICT, "키가 %s인 설정이 이미 존재합니다."),
     INVALID_LOCATION(HttpStatus.BAD_REQUEST, "위치 정보는 Polygon 형식이어야 합니다."),
     NOT_FOUND_CCTV(HttpStatus.NOT_FOUND, "ID가 %s인 CCTV를 찾을 수 없습니다."),
     MISSING_NVR_INFO(HttpStatus.BAD_REQUEST, "CCTV(ID: %s)에 NVR 정보가 설정되지 않았습니다."),

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/constant/SafersErrorCode.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/constant/SafersErrorCode.kt
@@ -10,7 +10,6 @@ enum class SafersErrorCode(
     NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "ID가 %s인 이벤트를 찾을 수 없습니다."),
     NOT_FOUND_SITE(HttpStatus.NOT_FOUND, "ID가 %s인 현장을 찾을 수 없습니다."),
     NOT_FOUND_CONFIGURATION(HttpStatus.NOT_FOUND, "키가 %s인 설정을 찾을 수 없습니다."),
-    NOT_FOUND_CONFIGURATION_BY_ID(HttpStatus.NOT_FOUND, "ID가 %s인 설정을 찾을 수 없습니다."),
     DUPLICATE_CONFIGURATION(HttpStatus.CONFLICT, "키가 %s인 설정이 이미 존재합니다."),
     INVALID_LOCATION(HttpStatus.BAD_REQUEST, "위치 정보는 Polygon 형식이어야 합니다."),
     NOT_FOUND_CCTV(HttpStatus.NOT_FOUND, "ID가 %s인 CCTV를 찾을 수 없습니다."),

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -32,7 +32,7 @@ class WeatherApiClient(
     companion object {
         private const val WEATHER_API_KEY = "WEATHER_API"
         private const val BASE_URL = "https://apihub.kma.go.kr"
-        private const val MAX_IN_MEMORY_SIZE = 50 * 1024 * 1024
+        private const val MAX_IN_MEMORY_SIZE = 1 * 1024 * 1024
         private const val CONNECT_TIMEOUT_MS = 5000
         private const val RESPONSE_TIMEOUT_SEC = 20L
         private const val IO_TIMEOUT_SEC = 20

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -30,7 +30,6 @@ class WeatherApiClient(
     private val webClient = buildWebClient()
 
     companion object {
-        private const val WEATHER_API_KEY = "WEATHER_API"
         private const val BASE_URL = "https://apihub.kma.go.kr"
         private const val MAX_IN_MEMORY_SIZE = 1 * 1024 * 1024
         private const val CONNECT_TIMEOUT_MS = 5000
@@ -153,6 +152,6 @@ class WeatherApiClient(
     }
 
     private fun getAuthKey(): String =
-        configurationService.findValue(WEATHER_API_KEY)
-            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, WEATHER_API_KEY)
+        configurationService.findWeatherApiKey()
+            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, "WEATHER_API")
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -19,7 +19,9 @@ import reactor.netty.resources.ConnectionProvider
 import reactor.util.retry.Retry
 import java.net.ConnectException
 import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.time.Duration
+import io.netty.handler.timeout.TimeoutException as NettyTimeoutException
 
 private val log = KotlinLogging.logger {}
 
@@ -36,7 +38,7 @@ class WeatherApiClient(
         private const val CONNECT_TIMEOUT_MS = 5000
         private const val RESPONSE_TIMEOUT_SEC = 20L
         private const val IO_TIMEOUT_SEC = 20
-        private const val MAX_RETRY_ATTEMPTS = 3L
+        private const val MAX_RETRY_ATTEMPTS = 2L
         private const val SUCCESS_RESULT_CODE = "00"
         private val OVERALL_TIMEOUT = Duration.ofSeconds(90)
         private val POOL_MAX_IDLE = Duration.ofSeconds(15)
@@ -122,6 +124,8 @@ class WeatherApiClient(
                 is ConnectException -> return true
                 is SocketException ->
                     if (cur.message?.contains("reset", ignoreCase = true) == true) return true
+                is NettyTimeoutException -> return true
+                is SocketTimeoutException -> return true
             }
             cur = cur.cause
         }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -31,6 +31,7 @@ class WeatherApiClient(
 
     companion object {
         private const val BASE_URL = "https://apihub.kma.go.kr"
+        private const val WEATHER_API_KEY = "WEATHER_API"
         private const val MAX_IN_MEMORY_SIZE = 1 * 1024 * 1024
         private const val CONNECT_TIMEOUT_MS = 5000
         private const val RESPONSE_TIMEOUT_SEC = 20L
@@ -164,6 +165,6 @@ class WeatherApiClient(
     }
 
     private fun getAuthKey(): String =
-        configurationService.findWeatherApiKey()
-            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, "WEATHER_API")
+        configurationService.findValue(WEATHER_API_KEY)
+            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, WEATHER_API_KEY)
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -1,7 +1,7 @@
 package com.pluxity.safers.weather.client
 
 import com.pluxity.common.core.exception.CustomException
-import com.pluxity.safers.configuration.repository.ConfigurationRepository
+import com.pluxity.safers.configuration.service.ConfigurationService
 import com.pluxity.safers.global.constant.SafersErrorCode
 import com.pluxity.safers.weather.dto.WeatherApiResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -25,7 +25,7 @@ private val log = KotlinLogging.logger {}
 
 @Component
 class WeatherApiClient(
-    private val configurationRepository: ConfigurationRepository,
+    private val configurationService: ConfigurationService,
 ) {
     private val webClient = buildWebClient()
 
@@ -153,8 +153,6 @@ class WeatherApiClient(
     }
 
     private fun getAuthKey(): String =
-        (
-            configurationRepository.findByKey(WEATHER_API_KEY)
-                ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, WEATHER_API_KEY)
-        ).value
+        configurationService.findValue(WEATHER_API_KEY)
+            ?: throw CustomException(SafersErrorCode.NOT_FOUND_CONFIGURATION, WEATHER_API_KEY)
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -1,31 +1,41 @@
 package com.pluxity.safers.weather.client
 
-import com.pluxity.common.core.config.WebClientFactory
 import com.pluxity.common.core.exception.CustomException
 import com.pluxity.safers.configuration.repository.ConfigurationRepository
 import com.pluxity.safers.global.constant.SafersErrorCode
 import com.pluxity.safers.weather.dto.WeatherApiResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.handler.timeout.WriteTimeoutHandler
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import reactor.netty.http.client.HttpClient
+import reactor.netty.http.client.PrematureCloseException
+import reactor.netty.resources.ConnectionProvider
+import reactor.util.retry.Retry
+import java.io.IOException
+import java.time.Duration
 
 private val log = KotlinLogging.logger {}
 
 @Component
 class WeatherApiClient(
-    webClientFactory: WebClientFactory,
     private val configurationRepository: ConfigurationRepository,
 ) {
-    private val webClient =
-        webClientFactory.createClient(
-            baseUrl = "https://apihub.kma.go.kr",
-            responseTimeoutMs = 60000,
-            readTimeoutMs = 60000,
-        )
+    private val webClient = buildWebClient()
 
     companion object {
         private const val WEATHER_API_KEY = "WEATHER_API"
+        private const val BASE_URL = "https://apihub.kma.go.kr"
+        private const val MAX_IN_MEMORY_SIZE = 50 * 1024 * 1024
+        private const val CONNECT_TIMEOUT_MS = 5000
+        private const val RESPONSE_TIMEOUT_SEC = 60L
+        private const val IO_TIMEOUT_SEC = 60
+        private const val MAX_RETRY_ATTEMPTS = 3L
     }
 
     fun fetchUltraSrtFcst(
@@ -67,10 +77,66 @@ class WeatherApiClient(
                     .build()
             }.retrieve()
             .bodyToMono<WeatherApiResponse>()
-            .onErrorResume { e ->
+            .retryWhen(
+                Retry
+                    .backoff(MAX_RETRY_ATTEMPTS, Duration.ofMillis(500))
+                    .maxBackoff(Duration.ofSeconds(3))
+                    .filter(::isRetryable)
+                    .doBeforeRetry { signal ->
+                        log.warn {
+                            "$label API 재시도 #${signal.totalRetries() + 1} - baseDate: $baseDate, baseTime: $baseTime, " +
+                                "nx: $nx, ny: $ny, cause: ${signal.failure().rootMessage()}"
+                        }
+                    },
+            ).onErrorResume { e ->
                 log.error(e) { "$label API 호출 실패 - baseDate: $baseDate, baseTime: $baseTime, nx: $nx, ny: $ny" }
                 Mono.empty()
             }
+    }
+
+    private fun isRetryable(throwable: Throwable): Boolean {
+        var cur: Throwable? = throwable
+        while (cur != null) {
+            if (cur is PrematureCloseException || cur is IOException) return true
+            cur = cur.cause
+        }
+        return false
+    }
+
+    private fun Throwable.rootMessage(): String {
+        var cur: Throwable = this
+        while (cur.cause != null && cur.cause !== cur) cur = cur.cause!!
+        return "${cur::class.simpleName}: ${cur.message ?: ""}"
+    }
+
+    private fun buildWebClient(): WebClient {
+        val connectionProvider =
+            ConnectionProvider
+                .builder("kma-weather-pool")
+                .maxConnections(50)
+                .maxIdleTime(Duration.ofSeconds(15))
+                .maxLifeTime(Duration.ofSeconds(60))
+                .pendingAcquireTimeout(Duration.ofSeconds(60))
+                .evictInBackground(Duration.ofSeconds(30))
+                .build()
+
+        val httpClient =
+            HttpClient
+                .create(connectionProvider)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
+                .responseTimeout(Duration.ofSeconds(RESPONSE_TIMEOUT_SEC))
+                .doOnConnected { conn ->
+                    conn
+                        .addHandlerLast(ReadTimeoutHandler(IO_TIMEOUT_SEC))
+                        .addHandlerLast(WriteTimeoutHandler(IO_TIMEOUT_SEC))
+                }
+
+        return WebClient
+            .builder()
+            .baseUrl(BASE_URL)
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_IN_MEMORY_SIZE) }
+            .build()
     }
 
     private fun getAuthKey(): String =

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -17,7 +17,8 @@ import reactor.netty.http.client.HttpClient
 import reactor.netty.http.client.PrematureCloseException
 import reactor.netty.resources.ConnectionProvider
 import reactor.util.retry.Retry
-import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketException
 import java.time.Duration
 
 private val log = KotlinLogging.logger {}
@@ -33,9 +34,15 @@ class WeatherApiClient(
         private const val BASE_URL = "https://apihub.kma.go.kr"
         private const val MAX_IN_MEMORY_SIZE = 50 * 1024 * 1024
         private const val CONNECT_TIMEOUT_MS = 5000
-        private const val RESPONSE_TIMEOUT_SEC = 60L
-        private const val IO_TIMEOUT_SEC = 60
+        private const val RESPONSE_TIMEOUT_SEC = 20L
+        private const val IO_TIMEOUT_SEC = 20
         private const val MAX_RETRY_ATTEMPTS = 3L
+        private val OVERALL_TIMEOUT = Duration.ofSeconds(90)
+        private val POOL_MAX_IDLE = Duration.ofSeconds(15)
+        private val POOL_MAX_LIFE = Duration.ofSeconds(120)
+        private val POOL_PENDING_ACQUIRE = Duration.ofSeconds(30)
+        private val POOL_EVICT_INTERVAL = Duration.ofSeconds(30)
+        private const val POOL_MAX_CONNECTIONS = 50
     }
 
     fun fetchUltraSrtFcst(
@@ -88,7 +95,8 @@ class WeatherApiClient(
                                 "nx: $nx, ny: $ny, cause: ${signal.failure().rootMessage()}"
                         }
                     },
-            ).onErrorResume { e ->
+            ).timeout(OVERALL_TIMEOUT)
+            .onErrorResume { e ->
                 log.error(e) { "$label API 호출 실패 - baseDate: $baseDate, baseTime: $baseTime, nx: $nx, ny: $ny" }
                 Mono.empty()
             }
@@ -97,7 +105,12 @@ class WeatherApiClient(
     private fun isRetryable(throwable: Throwable): Boolean {
         var cur: Throwable? = throwable
         while (cur != null) {
-            if (cur is PrematureCloseException || cur is IOException) return true
+            when (cur) {
+                is PrematureCloseException -> return true
+                is ConnectException -> return true
+                is SocketException ->
+                    if (cur.message?.contains("reset", ignoreCase = true) == true) return true
+            }
             cur = cur.cause
         }
         return false
@@ -113,11 +126,11 @@ class WeatherApiClient(
         val connectionProvider =
             ConnectionProvider
                 .builder("kma-weather-pool")
-                .maxConnections(50)
-                .maxIdleTime(Duration.ofSeconds(15))
-                .maxLifeTime(Duration.ofSeconds(60))
-                .pendingAcquireTimeout(Duration.ofSeconds(60))
-                .evictInBackground(Duration.ofSeconds(30))
+                .maxConnections(POOL_MAX_CONNECTIONS)
+                .maxIdleTime(POOL_MAX_IDLE)
+                .maxLifeTime(POOL_MAX_LIFE)
+                .pendingAcquireTimeout(POOL_PENDING_ACQUIRE)
+                .evictInBackground(POOL_EVICT_INTERVAL)
                 .build()
 
         val httpClient =

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/weather/client/WeatherApiClient.kt
@@ -36,6 +36,7 @@ class WeatherApiClient(
         private const val RESPONSE_TIMEOUT_SEC = 20L
         private const val IO_TIMEOUT_SEC = 20
         private const val MAX_RETRY_ATTEMPTS = 3L
+        private const val SUCCESS_RESULT_CODE = "00"
         private val OVERALL_TIMEOUT = Duration.ofSeconds(90)
         private val POOL_MAX_IDLE = Duration.ofSeconds(15)
         private val POOL_MAX_LIFE = Duration.ofSeconds(120)
@@ -83,7 +84,18 @@ class WeatherApiClient(
                     .build()
             }.retrieve()
             .bodyToMono<WeatherApiResponse>()
-            .retryWhen(
+            .flatMap { response ->
+                val header = response.response.header
+                if (header.resultCode == SUCCESS_RESULT_CODE) {
+                    Mono.just(response)
+                } else {
+                    log.warn {
+                        "$label API 비정상 응답 - resultCode: ${header.resultCode}, resultMsg: ${header.resultMsg}, " +
+                            "baseDate: $baseDate, baseTime: $baseTime, nx: $nx, ny: $ny"
+                    }
+                    Mono.empty()
+                }
+            }.retryWhen(
                 Retry
                     .backoff(MAX_RETRY_ATTEMPTS, Duration.ofMillis(500))
                     .maxBackoff(Duration.ofSeconds(3))

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/dto/DummyDTOs.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/dto/DummyDTOs.kt
@@ -1,0 +1,8 @@
+package com.pluxity.safers.configuration.dto
+
+fun dummyConfigurationRequest(
+    key: String = "WEATHER_API",
+    value: String = "your-api-key",
+): ConfigurationRequest = ConfigurationRequest(key = key, value = value)
+
+fun dummyConfigurationUpdateRequest(value: String = "new-api-key"): ConfigurationUpdateRequest = ConfigurationUpdateRequest(value = value)

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/entity/DummyEntities.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/entity/DummyEntities.kt
@@ -1,0 +1,14 @@
+package com.pluxity.safers.configuration.entity
+
+import com.pluxity.common.core.test.withAudit
+import com.pluxity.common.core.test.withId
+
+fun dummyConfiguration(
+    id: Long? = 1L,
+    key: String = "WEATHER_API",
+    value: String = "your-api-key",
+): Configuration =
+    Configuration(
+        key = key,
+        value = value,
+    ).withId(id).withAudit()

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/service/ConfigurationServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/service/ConfigurationServiceTest.kt
@@ -18,7 +18,6 @@ import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.data.repository.findByIdOrNull
 
 class ConfigurationServiceTest :
     BehaviorSpec({
@@ -66,8 +65,8 @@ class ConfigurationServiceTest :
 
                 val result = service.create(request)
 
-                Then("설정 ID가 반환된다") {
-                    result shouldBe 5L
+                Then("설정 키가 반환된다") {
+                    result shouldBe "NEW_KEY"
                 }
 
                 Then("해당 키의 캐시가 무효화된다") {
@@ -89,13 +88,13 @@ class ConfigurationServiceTest :
             }
         }
 
-        Given("설정 단건 조회 (findById)") {
+        Given("설정 단건 조회 (findByKey)") {
 
-            When("존재하는 ID를 조회하면") {
+            When("존재하는 키를 조회하면") {
                 val configuration = dummyConfiguration(id = 1L, key = "WEATHER_API", value = "key-1")
-                every { configurationRepository.findByIdOrNull(1L) } returns configuration
+                every { configurationRepository.findByKey("WEATHER_API") } returns configuration
 
-                val result = service.findById(1L)
+                val result = service.findByKey("WEATHER_API")
 
                 Then("설정 정보가 반환된다") {
                     result.id shouldBe 1L
@@ -104,15 +103,15 @@ class ConfigurationServiceTest :
                 }
             }
 
-            When("존재하지 않는 ID를 조회하면") {
-                every { configurationRepository.findByIdOrNull(999L) } returns null
+            When("존재하지 않는 키를 조회하면") {
+                every { configurationRepository.findByKey("UNKNOWN") } returns null
 
-                Then("NOT_FOUND_CONFIGURATION_BY_ID 예외가 발생한다") {
+                Then("NOT_FOUND_CONFIGURATION 예외가 발생한다") {
                     val exception =
                         shouldThrow<CustomException> {
-                            service.findById(999L)
+                            service.findByKey("UNKNOWN")
                         }
-                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID
+                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION
                 }
             }
         }
@@ -150,12 +149,12 @@ class ConfigurationServiceTest :
 
         Given("설정 수정") {
 
-            When("존재하는 ID의 값을 수정하면") {
+            When("존재하는 키의 값을 수정하면") {
                 val configuration = dummyConfiguration(id = 1L, key = "WEATHER_API", value = "old")
                 val request = dummyConfigurationUpdateRequest(value = "new")
-                every { configurationRepository.findByIdOrNull(1L) } returns configuration
+                every { configurationRepository.findByKey("WEATHER_API") } returns configuration
 
-                service.update(1L, request)
+                service.update("WEATHER_API", request)
 
                 Then("값이 갱신된다") {
                     configuration.value shouldBe "new"
@@ -166,27 +165,27 @@ class ConfigurationServiceTest :
                 }
             }
 
-            When("존재하지 않는 ID를 수정하면") {
+            When("존재하지 않는 키를 수정하면") {
                 val request = dummyConfigurationUpdateRequest()
-                every { configurationRepository.findByIdOrNull(999L) } returns null
+                every { configurationRepository.findByKey("UNKNOWN") } returns null
 
-                Then("NOT_FOUND_CONFIGURATION_BY_ID 예외가 발생한다") {
+                Then("NOT_FOUND_CONFIGURATION 예외가 발생한다") {
                     val exception =
                         shouldThrow<CustomException> {
-                            service.update(999L, request)
+                            service.update("UNKNOWN", request)
                         }
-                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID
+                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION
                 }
             }
         }
 
         Given("설정 삭제") {
 
-            When("존재하는 ID를 삭제하면") {
+            When("존재하는 키를 삭제하면") {
                 val configuration = dummyConfiguration(id = 1L, key = "WEATHER_API")
-                every { configurationRepository.findByIdOrNull(1L) } returns configuration
+                every { configurationRepository.findByKey("WEATHER_API") } returns configuration
 
-                service.delete(1L)
+                service.delete("WEATHER_API")
 
                 Then("설정이 삭제된다") {
                     verify { configurationRepository.delete(configuration) }
@@ -197,15 +196,15 @@ class ConfigurationServiceTest :
                 }
             }
 
-            When("존재하지 않는 ID를 삭제하면") {
-                every { configurationRepository.findByIdOrNull(999L) } returns null
+            When("존재하지 않는 키를 삭제하면") {
+                every { configurationRepository.findByKey("UNKNOWN") } returns null
 
-                Then("NOT_FOUND_CONFIGURATION_BY_ID 예외가 발생한다") {
+                Then("NOT_FOUND_CONFIGURATION 예외가 발생한다") {
                     val exception =
                         shouldThrow<CustomException> {
-                            service.delete(999L)
+                            service.delete("UNKNOWN")
                         }
-                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID
+                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION
                 }
             }
         }

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/service/ConfigurationServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/service/ConfigurationServiceTest.kt
@@ -14,8 +14,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.springframework.cache.Cache
-import org.springframework.cache.CacheManager
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 
@@ -23,12 +21,7 @@ class ConfigurationServiceTest :
     BehaviorSpec({
 
         val configurationRepository: ConfigurationRepository = mockk(relaxed = true)
-        val cache: Cache = mockk(relaxed = true)
-        val cacheManager: CacheManager =
-            mockk {
-                every { getCache("configurations") } returns cache
-            }
-        val service = ConfigurationService(configurationRepository, cacheManager)
+        val service = ConfigurationService(configurationRepository)
 
         Given("설정 값 조회 (findValue)") {
 
@@ -68,10 +61,6 @@ class ConfigurationServiceTest :
                 Then("설정 키가 반환된다") {
                     result shouldBe "NEW_KEY"
                 }
-
-                Then("해당 키의 캐시가 무효화된다") {
-                    verify { cache.evict("NEW_KEY") }
-                }
             }
 
             When("이미 존재하는 키로 생성하면") {
@@ -97,7 +86,6 @@ class ConfigurationServiceTest :
                 val result = service.findByKey("WEATHER_API")
 
                 Then("설정 정보가 반환된다") {
-                    result.id shouldBe 1L
                     result.key shouldBe "WEATHER_API"
                     result.value shouldBe "key-1"
                 }
@@ -159,10 +147,6 @@ class ConfigurationServiceTest :
                 Then("값이 갱신된다") {
                     configuration.value shouldBe "new"
                 }
-
-                Then("해당 키의 캐시가 무효화된다") {
-                    verify { cache.evict("WEATHER_API") }
-                }
             }
 
             When("존재하지 않는 키를 수정하면") {
@@ -189,10 +173,6 @@ class ConfigurationServiceTest :
 
                 Then("설정이 삭제된다") {
                     verify { configurationRepository.delete(configuration) }
-                }
-
-                Then("해당 키의 캐시가 무효화된다") {
-                    verify { cache.evict("WEATHER_API") }
                 }
             }
 

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/service/ConfigurationServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/configuration/service/ConfigurationServiceTest.kt
@@ -1,0 +1,212 @@
+package com.pluxity.safers.configuration.service
+
+import com.pluxity.common.core.dto.PageSearchRequest
+import com.pluxity.common.core.exception.CustomException
+import com.pluxity.safers.configuration.dto.dummyConfigurationRequest
+import com.pluxity.safers.configuration.dto.dummyConfigurationUpdateRequest
+import com.pluxity.safers.configuration.entity.Configuration
+import com.pluxity.safers.configuration.entity.dummyConfiguration
+import com.pluxity.safers.configuration.repository.ConfigurationRepository
+import com.pluxity.safers.global.constant.SafersErrorCode
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+
+class ConfigurationServiceTest :
+    BehaviorSpec({
+
+        val configurationRepository: ConfigurationRepository = mockk(relaxed = true)
+        val cache: Cache = mockk(relaxed = true)
+        val cacheManager: CacheManager =
+            mockk {
+                every { getCache("configurations") } returns cache
+            }
+        val service = ConfigurationService(configurationRepository, cacheManager)
+
+        Given("설정 값 조회 (findValue)") {
+
+            When("존재하는 키를 조회하면") {
+                val configuration = dummyConfiguration(key = "WEATHER_API", value = "key-1")
+                every { configurationRepository.findByKey("WEATHER_API") } returns configuration
+
+                val result = service.findValue("WEATHER_API")
+
+                Then("값이 반환된다") {
+                    result shouldBe "key-1"
+                }
+            }
+
+            When("존재하지 않는 키를 조회하면") {
+                every { configurationRepository.findByKey("UNKNOWN") } returns null
+
+                val result = service.findValue("UNKNOWN")
+
+                Then("null이 반환된다") {
+                    result shouldBe null
+                }
+            }
+        }
+
+        Given("설정 생성") {
+
+            When("중복되지 않은 키로 생성하면") {
+                val request = dummyConfigurationRequest(key = "NEW_KEY", value = "v1")
+                val saved = dummyConfiguration(id = 5L, key = "NEW_KEY", value = "v1")
+
+                every { configurationRepository.findByKey("NEW_KEY") } returns null
+                every { configurationRepository.save(any()) } returns saved
+
+                val result = service.create(request)
+
+                Then("설정 ID가 반환된다") {
+                    result shouldBe 5L
+                }
+
+                Then("해당 키의 캐시가 무효화된다") {
+                    verify { cache.evict("NEW_KEY") }
+                }
+            }
+
+            When("이미 존재하는 키로 생성하면") {
+                val request = dummyConfigurationRequest(key = "DUPLICATED", value = "v1")
+                every { configurationRepository.findByKey("DUPLICATED") } returns dummyConfiguration(key = "DUPLICATED")
+
+                Then("DUPLICATE_CONFIGURATION 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.create(request)
+                        }
+                    exception.code shouldBe SafersErrorCode.DUPLICATE_CONFIGURATION
+                }
+            }
+        }
+
+        Given("설정 단건 조회 (findById)") {
+
+            When("존재하는 ID를 조회하면") {
+                val configuration = dummyConfiguration(id = 1L, key = "WEATHER_API", value = "key-1")
+                every { configurationRepository.findByIdOrNull(1L) } returns configuration
+
+                val result = service.findById(1L)
+
+                Then("설정 정보가 반환된다") {
+                    result.id shouldBe 1L
+                    result.key shouldBe "WEATHER_API"
+                    result.value shouldBe "key-1"
+                }
+            }
+
+            When("존재하지 않는 ID를 조회하면") {
+                every { configurationRepository.findByIdOrNull(999L) } returns null
+
+                Then("NOT_FOUND_CONFIGURATION_BY_ID 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.findById(999L)
+                        }
+                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID
+                }
+            }
+        }
+
+        Given("설정 전체 조회 (findAll)") {
+
+            When("목록을 조회하면") {
+                val configurations =
+                    listOf(
+                        dummyConfiguration(id = 1L, key = "A", value = "a"),
+                        dummyConfiguration(id = 2L, key = "B", value = "b"),
+                    )
+                every { configurationRepository.findAll(any<Pageable>()) } returns PageImpl(configurations)
+
+                val result = service.findAll(PageSearchRequest(page = 1, size = 10))
+
+                Then("페이징된 결과가 반환된다") {
+                    result.content.size shouldBe 2
+                    result.totalElements shouldBe 2
+                    result.pageNumber shouldBe 1
+                }
+            }
+
+            When("설정이 없으면") {
+                every { configurationRepository.findAll(any<Pageable>()) } returns PageImpl(emptyList<Configuration>())
+
+                val result = service.findAll(PageSearchRequest(page = 1, size = 10))
+
+                Then("빈 결과가 반환된다") {
+                    result.content.size shouldBe 0
+                    result.totalElements shouldBe 0
+                }
+            }
+        }
+
+        Given("설정 수정") {
+
+            When("존재하는 ID의 값을 수정하면") {
+                val configuration = dummyConfiguration(id = 1L, key = "WEATHER_API", value = "old")
+                val request = dummyConfigurationUpdateRequest(value = "new")
+                every { configurationRepository.findByIdOrNull(1L) } returns configuration
+
+                service.update(1L, request)
+
+                Then("값이 갱신된다") {
+                    configuration.value shouldBe "new"
+                }
+
+                Then("해당 키의 캐시가 무효화된다") {
+                    verify { cache.evict("WEATHER_API") }
+                }
+            }
+
+            When("존재하지 않는 ID를 수정하면") {
+                val request = dummyConfigurationUpdateRequest()
+                every { configurationRepository.findByIdOrNull(999L) } returns null
+
+                Then("NOT_FOUND_CONFIGURATION_BY_ID 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.update(999L, request)
+                        }
+                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID
+                }
+            }
+        }
+
+        Given("설정 삭제") {
+
+            When("존재하는 ID를 삭제하면") {
+                val configuration = dummyConfiguration(id = 1L, key = "WEATHER_API")
+                every { configurationRepository.findByIdOrNull(1L) } returns configuration
+
+                service.delete(1L)
+
+                Then("설정이 삭제된다") {
+                    verify { configurationRepository.delete(configuration) }
+                }
+
+                Then("해당 키의 캐시가 무효화된다") {
+                    verify { cache.evict("WEATHER_API") }
+                }
+            }
+
+            When("존재하지 않는 ID를 삭제하면") {
+                every { configurationRepository.findByIdOrNull(999L) } returns null
+
+                Then("NOT_FOUND_CONFIGURATION_BY_ID 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.delete(999L)
+                        }
+                    exception.code shouldBe SafersErrorCode.NOT_FOUND_CONFIGURATION_BY_ID
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## Summary
- 기상청 apihub API의 간헐적 커넥션 끊김(`PrematureCloseException` 등) 대응을 위해 WebClient에 커넥션 풀·타임아웃·재시도를 정비했습니다.
- authKey 조회를 DB에서 매번 읽던 구조를 `ConfigurationService` 전용 캐시(`weather-api-key`)로 분리해 호출 부하를 줄였습니다.
- HTTP 200이지만 `resultCode != "00"` 인 KMA 비즈니스 에러(NO_DATA, INVALID_REQUEST_PARAMETER_ERROR, LIMITED_NUMBER_OF_SERVICE_REQUESTS_EXCEEDS_ERROR 등)를 성공으로 취급해 저장 단계에 빈 리스트가 흘러 원인 추적이 어렵던 문제를 수정했습니다.

## 주요 변경
- **WebClient 재구성** (`WeatherApiClient.kt`)
  - 전용 `ConnectionProvider` (`kma-weather-pool`, maxIdle 15s / maxLife 120s / evict 30s)
  - connect 5s / response 20s / read+write 20s / 전체 상한 90s
  - retryable 필터 기반 jittered backoff 재시도 (최대 3회)
  - `maxInMemorySize` 1MB로 축소
- **authKey 캐싱** (`ConfigurationService.kt`)
  - `findWeatherApiKey()` 에 `@Cacheable("weather-api-key")` 적용, null은 캐시하지 않음
- **resultCode 검증**
  - `bodyToMono` 이후 `flatMap`에서 `resultCode == "00"` 확인
  - 비정상이면 resultCode/resultMsg/좌표·시간을 warn 로그로 남기고 `Mono.empty()` 로 해당 현장만 스킵 → 다른 현장 수집은 계속

## Test plan
- [ ] `./gradlew :apps:safers:test` (Weather 관련 테스트 통과 확인)
- [ ] 스테이징에서 authKey 정상 경로 수집이 여전히 동작하는지 확인
- [ ] 잘못된 좌표로 `resultCode=03(NO_DATA)` 유도 시 warn 로그만 남고 다른 현장 저장은 정상 진행되는지 확인
- [ ] 기상청 API 지연/커넥션 끊김 상황에서 재시도 후 정상 응답 복구 여부 모니터링