### PR TITLE
refactor: 이벤트 파일 다운로드를 JDK URLConnection 기반으로 전환

### DIFF
--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventFileDownloadService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventFileDownloadService.kt
@@ -3,6 +3,9 @@ package com.pluxity.safers.event.service
 import com.pluxity.common.file.service.FileService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
 import java.net.URI
 
 private val log = KotlinLogging.logger {}
@@ -14,32 +17,69 @@ class EventFileDownloadService(
     companion object {
         private const val CONNECT_TIMEOUT_MS = 5_000
         private const val READ_TIMEOUT_MS = 30_000
+        const val MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024
+        private const val BUFFER_SIZE = 8 * 1024
+        private val ALLOWED_SCHEMES = setOf("http", "https")
     }
 
     fun downloadAndInitiateUpload(fileUrl: String): Long? =
         try {
             val uri = URI.create(fileUrl)
-            if (uri.scheme == null || uri.authority == null) {
-                log.warn { "유효하지 않은 파일 URL (scheme 또는 authority 누락): $fileUrl" }
-                return null
+            when {
+                uri.scheme == null || uri.authority == null -> {
+                    log.warn { "유효하지 않은 파일 URL (scheme 또는 authority 누락): $fileUrl" }
+                    null
+                }
+                uri.scheme.lowercase() !in ALLOWED_SCHEMES -> {
+                    log.warn { "허용되지 않는 스킴: ${uri.scheme}, url: $fileUrl" }
+                    null
+                }
+                else -> download(uri, fileUrl)
             }
-            val fileName = uri.path.substringAfterLast('/')
-            val fileBytes =
-                uri
-                    .toURL()
-                    .openConnection()
-                    .apply {
-                        connectTimeout = CONNECT_TIMEOUT_MS
-                        readTimeout = READ_TIMEOUT_MS
-                    }.getInputStream()
-                    .use { it.readAllBytes() }
-
-            val contentType = determineContentType(fileName)
-            fileService.initiateUpload(fileBytes, fileName, contentType)
         } catch (e: Exception) {
             log.error(e) { "Failed to download and upload file: $fileUrl" }
             null
         }
+
+    private fun download(
+        uri: URI,
+        fileUrl: String,
+    ): Long? {
+        val connection = uri.toURL().openConnection() as HttpURLConnection
+        connection.connectTimeout = CONNECT_TIMEOUT_MS
+        connection.readTimeout = READ_TIMEOUT_MS
+        return try {
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                log.warn { "비정상 응답 코드: $responseCode, url: $fileUrl" }
+                return null
+            }
+            val fileBytes =
+                connection.inputStream.use { readBounded(it) } ?: run {
+                    log.warn { "파일 크기 한도 초과 (> ${MAX_DOWNLOAD_SIZE}B): $fileUrl" }
+                    return null
+                }
+            val fileName = uri.path.substringAfterLast('/')
+            val contentType = determineContentType(fileName)
+            fileService.initiateUpload(fileBytes, fileName, contentType)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun readBounded(input: InputStream): ByteArray? {
+        val out = ByteArrayOutputStream()
+        val buffer = ByteArray(BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val n = input.read(buffer)
+            if (n == -1) break
+            total += n
+            if (total > MAX_DOWNLOAD_SIZE) return null
+            out.write(buffer, 0, n)
+        }
+        return out.toByteArray()
+    }
 
     private fun determineContentType(fileName: String): String =
         when (fileName.substringAfterLast('.', "").lowercase()) {

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventFileDownloadService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventFileDownloadService.kt
@@ -1,10 +1,8 @@
 package com.pluxity.safers.event.service
 
-import com.pluxity.common.core.config.WebClientFactory
 import com.pluxity.common.file.service.FileService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.bodyToMono
 import java.net.URI
 
 private val log = KotlinLogging.logger {}
@@ -12,8 +10,12 @@ private val log = KotlinLogging.logger {}
 @Service
 class EventFileDownloadService(
     private val fileService: FileService,
-    private val webClientFactory: WebClientFactory,
 ) {
+    companion object {
+        private const val CONNECT_TIMEOUT_MS = 5_000
+        private const val READ_TIMEOUT_MS = 30_000
+    }
+
     fun downloadAndInitiateUpload(fileUrl: String): Long? =
         try {
             val uri = URI.create(fileUrl)
@@ -22,16 +24,15 @@ class EventFileDownloadService(
                 return null
             }
             val fileName = uri.path.substringAfterLast('/')
-            val baseUrl = "${uri.scheme}://${uri.authority}"
             val fileBytes =
-                webClientFactory
-                    .createClient(baseUrl)
-                    .get()
-                    .uri(uri.path)
-                    .retrieve()
-                    .bodyToMono<ByteArray>()
-                    .block()
-                    ?: error("파일 다운로드에 실패했습니다: $fileUrl")
+                uri
+                    .toURL()
+                    .openConnection()
+                    .apply {
+                        connectTimeout = CONNECT_TIMEOUT_MS
+                        readTimeout = READ_TIMEOUT_MS
+                    }.getInputStream()
+                    .use { it.readAllBytes() }
 
             val contentType = determineContentType(fileName)
             fileService.initiateUpload(fileBytes, fileName, contentType)

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventFileDownloadServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventFileDownloadServiceTest.kt
@@ -1,65 +1,82 @@
 package com.pluxity.safers.event.service
 
-import com.pluxity.common.core.config.WebClientFactory
 import com.pluxity.common.file.service.FileService
+import com.sun.net.httpserver.HttpServer
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.springframework.core.ParameterizedTypeReference
-import org.springframework.web.reactive.function.client.WebClient
-import reactor.core.publisher.Mono
+import java.net.InetSocketAddress
 
 class EventFileDownloadServiceTest :
     BehaviorSpec({
 
         val fileService: FileService = mockk(relaxed = true)
-        val webClientFactory: WebClientFactory = mockk()
-        val service = EventFileDownloadService(fileService, webClientFactory)
+        val service = EventFileDownloadService(fileService)
+
+        lateinit var server: HttpServer
+        var port = 0
+
+        beforeSpec {
+            server =
+                HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+                    createContext("/path/image.jpg") { exchange ->
+                        val body = "test-content".toByteArray()
+                        exchange.sendResponseHeaders(200, body.size.toLong())
+                        exchange.responseBody.use { it.write(body) }
+                    }
+                    createContext("/videos/clip.mp4") { exchange ->
+                        val body = "video-content".toByteArray()
+                        exchange.sendResponseHeaders(200, body.size.toLong())
+                        exchange.responseBody.use { it.write(body) }
+                    }
+                    createContext("/error/file.png") { exchange ->
+                        exchange.sendResponseHeaders(500, -1)
+                        exchange.close()
+                    }
+                    start()
+                }
+            port = server.address.port
+        }
+
+        afterSpec {
+            server.stop(0)
+        }
 
         Given("파일 다운로드 및 업로드") {
 
             When("정상적인 URL로 파일을 다운로드하면") {
-                val fileBytes = "test-content".toByteArray()
-                val requestHeadersUriSpec: WebClient.RequestHeadersUriSpec<*> = mockk()
-                val requestHeadersSpec: WebClient.RequestHeadersSpec<*> = mockk()
-                val responseSpec: WebClient.ResponseSpec = mockk()
-                val webClient: WebClient = mockk()
+                every { fileService.initiateUpload(any(), "image.jpg", "image/jpeg") } returns 10L
 
-                every { webClientFactory.createClient("https://example.com") } returns webClient
-                every { webClient.get() } returns requestHeadersUriSpec
-                every { requestHeadersUriSpec.uri("/path/image.jpg") } returns requestHeadersSpec
-                every { requestHeadersSpec.retrieve() } returns responseSpec
-                every { responseSpec.bodyToMono(any<ParameterizedTypeReference<ByteArray>>()) } returns Mono.just(fileBytes)
-                every { fileService.initiateUpload(fileBytes, "image.jpg", "image/jpeg") } returns 10L
-
-                val result = service.downloadAndInitiateUpload("https://example.com/path/image.jpg")
+                val result = service.downloadAndInitiateUpload("http://127.0.0.1:$port/path/image.jpg")
 
                 Then("파일 ID가 반환된다") {
                     result shouldBe 10L
                 }
 
                 Then("올바른 content type으로 업로드된다") {
-                    verify { fileService.initiateUpload(fileBytes, "image.jpg", "image/jpeg") }
+                    verify {
+                        fileService.initiateUpload(
+                            match { String(it) == "test-content" },
+                            "image.jpg",
+                            "image/jpeg",
+                        )
+                    }
                 }
             }
 
             When("다운로드 중 예외가 발생하면") {
-                val webClient: WebClient = mockk()
-                val requestHeadersUriSpec: WebClient.RequestHeadersUriSpec<*> = mockk()
-                val requestHeadersSpec: WebClient.RequestHeadersSpec<*> = mockk()
-                val responseSpec: WebClient.ResponseSpec = mockk()
+                val result = service.downloadAndInitiateUpload("http://127.0.0.1:$port/error/file.png")
 
-                every { webClientFactory.createClient("https://fail.com") } returns webClient
-                every { webClient.get() } returns requestHeadersUriSpec
-                every { requestHeadersUriSpec.uri("/error/file.png") } returns requestHeadersSpec
-                every { requestHeadersSpec.retrieve() } returns responseSpec
-                every { responseSpec.bodyToMono(any<ParameterizedTypeReference<ByteArray>>()) } returns
-                    Mono.error(RuntimeException("connection failed"))
+                Then("null이 반환된다") {
+                    result.shouldBeNull()
+                }
+            }
 
-                val result = service.downloadAndInitiateUpload("https://fail.com/error/file.png")
+            When("유효하지 않은 URL을 전달하면") {
+                val result = service.downloadAndInitiateUpload("not-a-valid-url")
 
                 Then("null이 반환된다") {
                     result.shouldBeNull()
@@ -67,24 +84,19 @@ class EventFileDownloadServiceTest :
             }
 
             When("mp4 파일을 다운로드하면") {
-                val fileBytes = "video-content".toByteArray()
-                val webClient: WebClient = mockk()
-                val requestHeadersUriSpec: WebClient.RequestHeadersUriSpec<*> = mockk()
-                val requestHeadersSpec: WebClient.RequestHeadersSpec<*> = mockk()
-                val responseSpec: WebClient.ResponseSpec = mockk()
+                every { fileService.initiateUpload(any(), "clip.mp4", "video/mp4") } returns 20L
 
-                every { webClientFactory.createClient("https://example.com") } returns webClient
-                every { webClient.get() } returns requestHeadersUriSpec
-                every { requestHeadersUriSpec.uri("/videos/clip.mp4") } returns requestHeadersSpec
-                every { requestHeadersSpec.retrieve() } returns responseSpec
-                every { responseSpec.bodyToMono(any<ParameterizedTypeReference<ByteArray>>()) } returns Mono.just(fileBytes)
-                every { fileService.initiateUpload(fileBytes, "clip.mp4", "video/mp4") } returns 20L
-
-                val result = service.downloadAndInitiateUpload("https://example.com/videos/clip.mp4")
+                val result = service.downloadAndInitiateUpload("http://127.0.0.1:$port/videos/clip.mp4")
 
                 Then("video/mp4 content type으로 업로드된다") {
                     result shouldBe 20L
-                    verify { fileService.initiateUpload(fileBytes, "clip.mp4", "video/mp4") }
+                    verify {
+                        fileService.initiateUpload(
+                            match { String(it) == "video-content" },
+                            "clip.mp4",
+                            "video/mp4",
+                        )
+                    }
                 }
             }
         }

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventFileDownloadServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventFileDownloadServiceTest.kt
@@ -75,8 +75,16 @@ class EventFileDownloadServiceTest :
                 }
             }
 
-            When("유효하지 않은 URL을 전달하면") {
+            When("스킴 또는 authority가 없는 URL을 전달하면") {
                 val result = service.downloadAndInitiateUpload("not-a-valid-url")
+
+                Then("null이 반환된다") {
+                    result.shouldBeNull()
+                }
+            }
+
+            When("허용되지 않는 스킴(file)의 URL을 전달하면") {
+                val result = service.downloadAndInitiateUpload("file:///etc/passwd")
 
                 Then("null이 반환된다") {
                     result.shouldBeNull()


### PR DESCRIPTION
## Summary
- 정적 이미지/영상 단순 GET 다운로드 경로를 Reactor Netty WebClient → JDK `URL.openConnection()` 으로 전환
- 일부 CCTV 장비가 응답에서 bare LF 를 사용해 Netty가 `InvalidLineSeparatorException` WARN 을 연속 출력하던 로그 노이즈 제거
- 테스트는 WebClient mock 체인 → 로컬 `HttpServer` 기반 실제 HTTP 왕복 검증으로 재작성

## 배경
- 운영 로그에 반복 출력되던 패턴:
  ```
  [HttpClientConnect] The connection observed an error
  io.netty.handler.codec.http.InvalidLineSeparatorException: Line Feed must be preceded by Carriage Return ...
  ```
- 원인: 특정 CCTV 장비(`14.51.233.128:8108` 등)의 HTTP 서버가 응답 헤더 라인 구분자로 `\r\n` 대신 `\n` 사용. Netty 는 RFC 7230 엄격 준수라 거부
- 현재 요청의 응답 body 는 성공 emit되고 `initiateUpload` 도 실행되지만, keep-alive 채널에서 이후 발생하는 파싱 실패로 WARN 로그가 계속 쌓임

## 변경 내용
- `EventFileDownloadService`
  - `WebClientFactory` 의존 제거
  - `URI.toURL().openConnection()` 으로 단순화, `connectTimeout=5s` / `readTimeout=30s` 명시
- `EventFileDownloadServiceTest`
  - WebClient 체인 mocking 제거
  - `com.sun.net.httpserver.HttpServer` 로 127.0.0.1 임시 포트 바인딩
  - image.jpg / mp4 / 500 에러 / 잘못된 URL 네 시나리오 실제 HTTP 로 검증

## 설계 선택
- 정적 파일 GET 은 reactive 체인의 이점(backpressure·스트리밍·비동기 체이닝)을 쓰지 않음
- 호출부가 이미 `.block()` 으로 동기화하고 있어 블로킹 I/O 전환에 부작용 없음
- JDK `URLConnection` 은 이런 비표준 HTTP 응답을 관대하게 처리해 같은 장비에서 오던 로그 노이즈가 사라질 것으로 기대

## Test plan
- [x] `./gradlew :apps:safers:test --tests "com.pluxity.safers.event.service.EventFileDownloadServiceTest"` 통과
- [x] 로컬 실 환경에서 정상 파일 다운로드/업로드 동작 확인 (저자)
- [ ] 스테이징에서 bare-LF 장비 대상 다운로드 시 WARN 로그 사라짐 확인
- [ ] 기존에 성공하던 장비의 다운로드는 계속 성공하는지 확인