### PR TITLE
feat: 중앙 telemetry ingest — InfluxDB 배치 적재

### DIFF
--- a/apps/safers/build.gradle.kts
+++ b/apps/safers/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(rootProject.libs.bundles.coroutines)
     implementation(rootProject.libs.logbook)
     implementation(rootProject.libs.spring.boot.starter.data.redis)
+    implementation(rootProject.libs.influxdb)
 
     // Hibernate Spatial + JTS (Site polygon)
     implementation(rootProject.libs.bundles.spatial)

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxConfig.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxConfig.kt
@@ -27,21 +27,24 @@ class InfluxConfig {
         )
 
     @Bean(destroyMethod = "close")
-    fun writeApi(client: InfluxDBClient): WriteApi {
+    fun writeApi(
+        client: InfluxDBClient,
+        props: InfluxProperties,
+    ): WriteApi {
         val writeApi =
             client.makeWriteApi(
                 WriteOptions
                     .builder()
-                    .batchSize(1000) // 1000건 모이면 flush
-                    .flushInterval(1000) // 또는 1초마다 강제 flush (먼저 도달)
-                    .bufferLimit(10_000) // buffer 1만 건 초과 시 백프레셔
-                    .retryInterval(5_000) // 실패 시 5초 후 재시도
-                    .maxRetries(3)
+                    .batchSize(props.batchSize)
+                    .flushInterval(props.flushIntervalMs)
+                    .bufferLimit(props.bufferLimit)
+                    .retryInterval(props.retryIntervalMs)
+                    .maxRetries(props.maxRetries)
                     .build(),
             )
 
-        writeApi.listenEvents(WriteErrorEvent::class.java) {
-            log.error { "[InfluxDB] write failed (final)" }
+        writeApi.listenEvents(WriteErrorEvent::class.java) { event ->
+            log.error(event.throwable) { "[InfluxDB] write failed: ${event.throwable.message}" }
             // dead-letter?
         }
         writeApi.listenEvents(WriteRetriableErrorEvent::class.java) {

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxConfig.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxConfig.kt
@@ -1,0 +1,56 @@
+package com.pluxity.safers.ingest.config
+
+import com.influxdb.client.InfluxDBClient
+import com.influxdb.client.InfluxDBClientFactory
+import com.influxdb.client.WriteApi
+import com.influxdb.client.WriteOptions
+import com.influxdb.client.write.events.BackpressureEvent
+import com.influxdb.client.write.events.WriteErrorEvent
+import com.influxdb.client.write.events.WriteRetriableErrorEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+private val log = KotlinLogging.logger {}
+
+@Configuration
+@EnableConfigurationProperties(InfluxProperties::class)
+class InfluxConfig {
+    @Bean(destroyMethod = "close")
+    fun influxClient(props: InfluxProperties): InfluxDBClient =
+        InfluxDBClientFactory.create(
+            props.url,
+            props.token.toCharArray(),
+            props.org,
+            props.bucket,
+        )
+
+    @Bean(destroyMethod = "close")
+    fun writeApi(client: InfluxDBClient): WriteApi {
+        val writeApi =
+            client.makeWriteApi(
+                WriteOptions
+                    .builder()
+                    .batchSize(1000) // 1000건 모이면 flush
+                    .flushInterval(1000) // 또는 1초마다 강제 flush (먼저 도달)
+                    .bufferLimit(10_000) // buffer 1만 건 초과 시 백프레셔
+                    .retryInterval(5_000) // 실패 시 5초 후 재시도
+                    .maxRetries(3)
+                    .build(),
+            )
+
+        writeApi.listenEvents(WriteErrorEvent::class.java) {
+            log.error { "[InfluxDB] write failed (final)" }
+            // dead-letter?
+        }
+        writeApi.listenEvents(WriteRetriableErrorEvent::class.java) {
+            log.warn { "[InfluxDB] write retriable error — will retry" }
+        }
+        writeApi.listenEvents(BackpressureEvent::class.java) {
+            log.warn { "[InfluxDB] backpressure — buffer 임계 도달, 송신 속도 ↓" }
+        }
+
+        return writeApi
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxProperties.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxProperties.kt
@@ -1,0 +1,11 @@
+package com.pluxity.safers.ingest.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "influx")
+data class InfluxProperties(
+    val url: String,
+    val token: String,
+    val org: String,
+    val bucket: String,
+)

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxProperties.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/config/InfluxProperties.kt
@@ -8,4 +8,9 @@ data class InfluxProperties(
     val token: String,
     val org: String,
     val bucket: String,
+    val batchSize: Int = 1000, // 1000건 모이면 flush
+    val flushIntervalMs: Int = 1000, // 또는 1초마다 강제 flush (먼저 도달)
+    val bufferLimit: Int = 10000, // buffer 1만 건 초과 시 백프레셔
+    val retryIntervalMs: Int = 5000, // 실패 시 5초 후 재시도
+    val maxRetries: Int = 3, // 최대 3번 재시도
 )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/controller/TelemetryController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/controller/TelemetryController.kt
@@ -2,7 +2,8 @@ package com.pluxity.safers.ingest.controller
 
 import com.pluxity.common.core.response.DataResponseBody
 import com.pluxity.common.core.response.ErrorResponseBody
-import com.pluxity.safers.ingest.dto.TelemetryRequest
+import com.pluxity.safers.ingest.dto.TelemetryBatchRequest
+import com.pluxity.safers.ingest.service.TelemetryService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -20,10 +21,12 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v1/sites/{siteId}/telemetry")
 @Tag(name = "Ingest - Telemetry", description = "수집모듈로부터 정규화된 시계열 측정값 수신 (X-Api-Key 인증). siteId 는 URL path.")
-class TelemetryController {
+class TelemetryController(
+    private val telemetryService: TelemetryService,
+) {
     @Operation(
-        summary = "telemetry 적재",
-        description = "정규화 envelope을 받아 InfluxDB 배치 큐에 enqueue 후 즉시 200 응답.",
+        summary = "telemetry 배치 적재",
+        description = "수집모듈 forwarder 가 묶은 envelope 배치(1~500건)를 받아 InfluxDB 배치 큐에 enqueue 후 즉시 200 응답.",
     )
     @ApiResponses(
         value = [
@@ -43,9 +46,9 @@ class TelemetryController {
     @PostMapping
     fun ingest(
         @PathVariable siteId: Long,
-        @Valid @RequestBody request: TelemetryRequest,
+        @Valid @RequestBody request: TelemetryBatchRequest,
     ): ResponseEntity<DataResponseBody<Unit>> {
-        // TODO: InfluxDB writer enqueue (siteId 를 measurement tag 로 부착)
+        telemetryService.ingest(siteId, request.samples)
         return ResponseEntity.ok(DataResponseBody(Unit))
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/TelemetryDtos.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/TelemetryDtos.kt
@@ -1,8 +1,18 @@
 package com.pluxity.safers.ingest.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
+
+@Schema(description = "telemetry 배치 수집 요청 — 수집모듈 forwarder 가 1초/100건 단위로 묶어 전송")
+data class TelemetryBatchRequest(
+    @field:Valid
+    @field:Size(min = 1, max = 500)
+    @field:Schema(description = "정규화 envelope 묶음 (1~500건)")
+    val samples: List<TelemetryRequest>,
+)
 
 @Schema(description = "정규화 telemetry envelope (수집모듈이 forward)")
 data class TelemetryRequest(

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriter.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriter.kt
@@ -1,0 +1,52 @@
+package com.pluxity.safers.ingest.persistence.influx
+
+import com.influxdb.client.WriteApi
+import com.influxdb.client.domain.WritePrecision
+import com.influxdb.client.write.Point
+import com.pluxity.safers.ingest.config.InfluxProperties
+import com.pluxity.safers.ingest.dto.TelemetryRequest
+import org.springframework.stereotype.Component
+import java.time.ZoneId
+
+@Component
+class InfluxTelemetryWriter(
+    private val writeApi: WriteApi,
+    private val props: InfluxProperties,
+) {
+    fun write(
+        siteId: Long,
+        request: TelemetryRequest,
+    ) {
+        val point =
+            Point
+                .measurement(request.measurement)
+                .addTags(request.tags)
+                .addTag(SITE_ID_TAG, siteId.toString()) // path siteId 강제 — 위변조 차단
+                .also { p -> request.fields.forEach { (k, v) -> addField(p, k, v) } }
+                .time(request.timestamp.atZone(KST).toInstant(), WritePrecision.MS)
+
+        writeApi.writePoint(props.bucket, props.org, point)
+    }
+
+    private fun addField(
+        point: Point,
+        key: String,
+        value: Any,
+    ) {
+        when (value) {
+            is Int -> point.addField(key, value)
+            is Long -> point.addField(key, value)
+            is Double -> point.addField(key, value)
+            is Float -> point.addField(key, value.toDouble())
+            is Number -> point.addField(key, value.toDouble())
+            is Boolean -> point.addField(key, value)
+            is String -> point.addField(key, value)
+            else -> point.addField(key, value.toString())
+        }
+    }
+
+    companion object {
+        private const val SITE_ID_TAG = "site_id"
+        private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriter.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriter.kt
@@ -34,11 +34,7 @@ class InfluxTelemetryWriter(
         value: Any,
     ) {
         when (value) {
-            is Int -> point.addField(key, value)
-            is Long -> point.addField(key, value)
-            is Double -> point.addField(key, value)
-            is Float -> point.addField(key, value.toDouble())
-            is Number -> point.addField(key, value.toDouble())
+            is Number -> point.addField(key, value)
             is Boolean -> point.addField(key, value)
             is String -> point.addField(key, value)
             else -> point.addField(key, value.toString())

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/TelemetryService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/TelemetryService.kt
@@ -1,0 +1,17 @@
+package com.pluxity.safers.ingest.service
+
+import com.pluxity.safers.ingest.dto.TelemetryRequest
+import com.pluxity.safers.ingest.persistence.influx.InfluxTelemetryWriter
+import org.springframework.stereotype.Service
+
+@Service
+class TelemetryService(
+    private val writer: InfluxTelemetryWriter,
+) {
+    fun ingest(
+        siteId: Long,
+        samples: List<TelemetryRequest>,
+    ) {
+        samples.forEach { writer.write(siteId, it) }
+    }
+}

--- a/apps/safers/src/main/resources/application-local.yml
+++ b/apps/safers/src/main/resources/application-local.yml
@@ -52,3 +52,10 @@ llm:
   ollama:
     base-url: http://192.168.10.182:11434
     model: qwen3:14b
+
+
+influx:
+  url: ${INFLUX_URL:http://localhost:8086}
+  token: ${INFLUX_TOKEN:pluxity}
+  org: ${INFLUX_ORG:pluxity}
+  bucket: ${INFLUX_BUCKET:safety}

--- a/apps/safers/src/main/resources/application-prod.yml
+++ b/apps/safers/src/main/resources/application-prod.yml
@@ -53,3 +53,9 @@ llm:
   ollama:
     base-url: http://192.168.10.182:11434
     model: qwen3:14b
+
+influx:
+  url: ${INFLUX_URL}
+  token: ${INFLUX_TOKEN}
+  org: ${INFLUX_ORG:pluxity}
+  bucket: ${INFLUX_BUCKET:safety}

--- a/apps/safers/src/main/resources/application-prod.yml
+++ b/apps/safers/src/main/resources/application-prod.yml
@@ -59,3 +59,8 @@ influx:
   token: ${INFLUX_TOKEN}
   org: ${INFLUX_ORG:pluxity}
   bucket: ${INFLUX_BUCKET:safety}
+  batch-size: ${INFLUX_BATCH_SIZE:1000}
+  flush-interval-ms: ${INFLUX_FLUSH_INTERVAL_MS:1000}
+  buffer-limit: ${INFLUX_BUFFER_LIMIT:10000}
+  retry-interval-ms: ${INFLUX_RETRY_INTERVAL_MS:5000}
+  max-retries: ${INFLUX_MAX_RETRIES:3}

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriterTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriterTest.kt
@@ -1,0 +1,166 @@
+package com.pluxity.safers.ingest.persistence.influx
+
+import com.influxdb.client.WriteApi
+import com.influxdb.client.write.Point
+import com.pluxity.safers.ingest.config.InfluxProperties
+import com.pluxity.safers.ingest.dto.SourceType
+import com.pluxity.safers.ingest.dto.TelemetryRequest
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class InfluxTelemetryWriterTest :
+    BehaviorSpec({
+
+        val writeApi: WriteApi = mockk(relaxed = true)
+        val props =
+            InfluxProperties(
+                url = "http://localhost:8086",
+                token = "pluxity",
+                org = "pluxity",
+                bucket = "safety",
+            )
+        val writer = InfluxTelemetryWriter(writeApi, props)
+
+        Given("정상 가스 telemetry 요청") {
+            val request =
+                TelemetryRequest(
+                    sourceType = SourceType.GAS,
+                    sourceId = "GAS-MH203-01",
+                    timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                    measurement = "gas_reading",
+                    tags =
+                        mapOf(
+                            "device_id" to "GAS-MH203-01",
+                            "gas" to "H2S",
+                            "unit" to "PPM",
+                        ),
+                    fields =
+                        mapOf(
+                            "value" to 3.1,
+                            "battery" to 87,
+                        ),
+                )
+
+            When("siteId=42 로 write 호출") {
+                writer.write(siteId = 42L, request = request)
+
+                Then("InfluxProperties 의 bucket / org 로 writePoint 호출") {
+                    verify { writeApi.writePoint("safety", "pluxity", any()) }
+                }
+
+                Then("line protocol 에 measurement / tags / fields 가 모두 들어감") {
+                    val captured = slot<Point>()
+                    verify { writeApi.writePoint(any(), any(), capture(captured)) }
+                    val line = captured.captured.toLineProtocol()
+
+                    line shouldContain "gas_reading"
+                    line shouldContain "site_id=42"
+                    line shouldContain "device_id=GAS-MH203-01"
+                    line shouldContain "gas=H2S"
+                    line shouldContain "unit=PPM"
+                    line shouldContain "value=3.1"
+                    line shouldContain "battery=87i"
+                }
+            }
+        }
+
+        Given("request.tags 에 site_id 가 위변조로 들어온 경우") {
+            val request =
+                TelemetryRequest(
+                    sourceType = SourceType.GAS,
+                    sourceId = "GAS-MH203-01",
+                    timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                    measurement = "gas_reading",
+                    tags =
+                        mapOf(
+                            "site_id" to "99", // ← 위변조 시도
+                            "gas" to "H2S",
+                        ),
+                    fields = mapOf("value" to 3.1),
+                )
+
+            When("siteId=42 로 write 호출") {
+                writer.write(siteId = 42L, request = request)
+
+                Then("path siteId(42)가 우선되어 위변조가 차단됨") {
+                    val captured = slot<Point>()
+                    verify { writeApi.writePoint(any(), any(), capture(captured)) }
+                    val line = captured.captured.toLineProtocol()
+
+                    line shouldContain "site_id=42"
+                    line shouldNotContain "site_id=99"
+                }
+            }
+        }
+
+        Given("다양한 field 타입") {
+            val request =
+                TelemetryRequest(
+                    sourceType = SourceType.BAND,
+                    sourceId = "BAND-A1B2C3",
+                    timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                    measurement = "band_reading",
+                    tags = emptyMap(),
+                    fields =
+                        mapOf(
+                            "intVal" to 88,
+                            "longVal" to 1_000L,
+                            "doubleVal" to 36.7,
+                            "boolVal" to true,
+                            "stringVal" to "WORN",
+                        ),
+                )
+
+            When("write 호출") {
+                writer.write(siteId = 1L, request = request)
+
+                Then("Int / Long → 'i' 접미사, Double → 그대로, Boolean → true/false, String → 따옴표") {
+                    val captured = slot<Point>()
+                    verify { writeApi.writePoint(any(), any(), capture(captured)) }
+                    val line = captured.captured.toLineProtocol()
+
+                    line shouldContain "intVal=88i"
+                    line shouldContain "longVal=1000i"
+                    line shouldContain "doubleVal=36.7"
+                    line shouldContain "boolVal=true"
+                    line shouldContain "stringVal=\"WORN\""
+                }
+            }
+        }
+
+        Given("KST timestamp") {
+            val kstTimestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30) // KST 10:15:30
+            val request =
+                TelemetryRequest(
+                    sourceType = SourceType.GAS,
+                    sourceId = "GAS-001",
+                    timestamp = kstTimestamp,
+                    measurement = "gas_reading",
+                    tags = emptyMap(),
+                    fields = mapOf("value" to 1.0),
+                )
+
+            When("write 호출") {
+                writer.write(siteId = 1L, request = request)
+
+                Then("KST → UTC Instant 변환 (9시간 차) 후 ms 정밀도로 직렬화") {
+                    val captured = slot<Point>()
+                    verify { writeApi.writePoint(any(), any(), capture(captured)) }
+                    val line = captured.captured.toLineProtocol()
+
+                    val expectedMillis =
+                        kstTimestamp
+                            .atZone(ZoneId.of("Asia/Seoul"))
+                            .toInstant()
+                            .toEpochMilli()
+                    line shouldContain expectedMillis.toString()
+                }
+            }
+        }
+    })

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,9 @@ kotest-extensions-spring = "1.1.3"
 mockk = "1.14.5"
 springmockk = "5.0.1"
 
+# Influx
+influxdb = "7.3.0"
+
 [libraries]
 # Spring Boot Starters
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
@@ -64,6 +67,7 @@ kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 # Database
 postgresql = { module = "org.postgresql:postgresql" }
 h2 = { module = "com.h2database:h2" }
+influxdb = {module = "com.influxdb:influxdb-client-java", version.ref = "influxdb"}
 flyway-starter = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
 


### PR DESCRIPTION
## Summary

  - 중앙 telemetry ingest API 구현: `POST /v1/sites/{siteId}/telemetry`
  - 정규화 envelope 배치(1~500건) → InfluxDB 적재 흐름
  - path siteId 를 `site_id` tag 로 강제 주입하여 위변조 차단 (DRAFT §7.1)
  - 로컬 개발용 docker compose 추가 (postgres / redis / influxdb / minio)

  ---

  ## 관련 DRAFT 섹션

  - **§7.1** 데이터수집 — `POST /v1/sites/{siteId}/telemetry`
  - **§9.1** InfluxDB 전체 (인스턴스 구성, Writer 구현, site_id 강제 주입)
  - §3.1 — KST timestamp 처리
  - §11.3 — 중앙 ingest 패키지 구조

  ---

  ## 주요 결정사항

  - **클라이언트 7.3.0 / 서버 InfluxDB 2.x** — 라이브러리/서버 버전은 별개 축. 호환됨.
  - **WriteApi 비동기 배치** — `batchSize 1000`, `flushInterval 1s`, `bufferLimit 10_000`, retry 5s × 3회
  - **WriteListener 등록** — 에러 / 재시도 / backpressure 모두 로그로 가시화
  - **path siteId 강제 주입** — request.tags 에 `site_id` 가 와도 `Point` 빌드 마지막에 덮어씀 (보안)
  - **timestamp KST → UTC** — DRAFT §3.1 의 LocalDateTime + KST 가정 따라 변환 후 적재
  - **TelemetryBatchRequest 도입** — DRAFT 의 §11.2/§12.5 배치 
  - **패키지 구조 — DRAFT §11.3 일치** — `ingest/config/`, `ingest/persistence/influx/`, `ingest/service/`
  - 사용자가 200 OK 받은 후 InfluxDB 적재 실패 시 알 수 없음. 현재는 로그 / `WriteListener` 로만 감지
  ---

 ## Test plan

  - [x] 컴파일 통과 (`./gradlew :apps:safers:compileKotlin`)
  - [x] 단위 테스트 통과 — 위변조 차단 / 필드 타입 분기 / KST 변환 / line protocol 매핑
  - [x] 로컬 InfluxDB 띄운 상태에서 부팅 성공 (`docker compose up -d`)
  - [x] 수동 end-to-end 검증 — `POST /v1/sites/42/telemetry` 후 InfluxDB Data Explorer 에서 데이터 확인