### PR TITLE
feat: 안전 이벤트 ingest API + safers-collect 모듈 + DTO/enum 분리

### DIFF
--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/dto/CollectDtos.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/dto/CollectDtos.kt
@@ -1,5 +1,8 @@
 package com.pluxity.safersCollect.v1.collect.dto
 
+import com.pluxity.safersCollect.v1.collect.enums.GasType
+import com.pluxity.safersCollect.v1.collect.enums.GasUnit
+import com.pluxity.safersCollect.v1.collect.enums.WearState
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
@@ -36,10 +39,6 @@ data class GasMeasurement(
     val unit: GasUnit,
 )
 
-enum class GasType { O2, H2S, CO, CO2, CH4, LEL }
-
-enum class GasUnit { PPM, PERCENT }
-
 // ───────────────────────────────────── 스마트밴드 측정값 ─────────────────────────────────────
 
 @Schema(description = "스마트밴드 측정값 수집 요청")
@@ -64,5 +63,3 @@ data class BandVitals(
     @field:Schema(description = "산소포화도 (%)", example = "97", nullable = true) val spo2: Int? = null,
     @field:Schema(example = "4321", nullable = true) val step: Int? = null,
 )
-
-enum class WearState { WORN, OFF, UNKNOWN }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/dto/EventDtos.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/dto/EventDtos.kt
@@ -1,16 +1,15 @@
 package com.pluxity.safersCollect.v1.collect.dto
 
+import com.pluxity.safersCollect.v1.collect.enums.BandEventType
+import com.pluxity.safersCollect.v1.collect.enums.EventSeverity
+import com.pluxity.safersCollect.v1.collect.enums.GasType
+import com.pluxity.safersCollect.v1.collect.enums.GasUnit
+import com.pluxity.safersCollect.v1.collect.enums.SosTrigger
+import com.pluxity.safersCollect.v1.collect.enums.ThresholdLevel
+import com.pluxity.safersCollect.v1.collect.enums.VitalMetric
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
-
-enum class EventSeverity { INFO, WARNING, CRITICAL }
-
-enum class ThresholdLevel { WARNING, DANGER }
-
-enum class SosTrigger { BUTTON_LONG_PRESS, MOBILE_APP, MANUAL_DISPATCH }
-
-enum class VitalMetric { HEART_RATE, BODY_TEMP, SPO2 }
 
 // ───────────────────────────────────── 가스 임계 초과 이벤트 ─────────────────────────────────────
 
@@ -54,12 +53,6 @@ data class SosEventPayload(
 )
 
 // ───────────────────────────────────── 스마트밴드 이상 이벤트 ─────────────────────────────────────
-
-enum class BandEventType {
-    BAND_VITAL_ABNORMAL,
-    BAND_FALL_DETECTED,
-    BAND_OFFLINE,
-}
 
 @Schema(description = "스마트밴드 이상 이벤트 (eventType 으로 분기)")
 data class BandEventRequest(

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/BandEventType.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/BandEventType.kt
@@ -1,0 +1,7 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class BandEventType {
+    BAND_VITAL_ABNORMAL,
+    BAND_FALL_DETECTED,
+    BAND_OFFLINE,
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/EventSeverity.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/EventSeverity.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class EventSeverity { INFO, WARNING, CRITICAL }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/GasType.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/GasType.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class GasType { O2, H2S, CO, CO2, CH4, LEL }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/GasUnit.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/GasUnit.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class GasUnit { PPM, PERCENT }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/SosTrigger.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/SosTrigger.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class SosTrigger { BUTTON_LONG_PRESS, MOBILE_APP, MANUAL_DISPATCH }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/ThresholdLevel.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/ThresholdLevel.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class ThresholdLevel { WARNING, DANGER }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/VitalMetric.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/VitalMetric.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class VitalMetric { HEART_RATE, BODY_TEMP, SPO2 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/WearState.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/enums/WearState.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.collect.enums
+
+enum class WearState { WORN, OFF, UNKNOWN }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/controller/BandDeviceController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/controller/BandDeviceController.kt
@@ -3,7 +3,7 @@ package com.pluxity.safersCollect.v1.devices.controller
 import com.pluxity.safersCollect.v1.devices.dto.BandDeviceCreateRequest
 import com.pluxity.safersCollect.v1.devices.dto.BandDeviceResponse
 import com.pluxity.safersCollect.v1.devices.dto.BandDeviceUpdateRequest
-import com.pluxity.safersCollect.v1.devices.dto.DeviceStatus
+import com.pluxity.safersCollect.v1.devices.enums.DeviceStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/controller/GasDeviceController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/controller/GasDeviceController.kt
@@ -1,9 +1,9 @@
 package com.pluxity.safersCollect.v1.devices.controller
 
-import com.pluxity.safersCollect.v1.devices.dto.DeviceStatus
 import com.pluxity.safersCollect.v1.devices.dto.GasDeviceCreateRequest
 import com.pluxity.safersCollect.v1.devices.dto.GasDeviceResponse
 import com.pluxity.safersCollect.v1.devices.dto.GasDeviceUpdateRequest
+import com.pluxity.safersCollect.v1.devices.enums.DeviceStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/controller/SosDeviceController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/controller/SosDeviceController.kt
@@ -1,9 +1,9 @@
 package com.pluxity.safersCollect.v1.devices.controller
 
-import com.pluxity.safersCollect.v1.devices.dto.DeviceStatus
 import com.pluxity.safersCollect.v1.devices.dto.SosDeviceCreateRequest
 import com.pluxity.safersCollect.v1.devices.dto.SosDeviceResponse
 import com.pluxity.safersCollect.v1.devices.dto.SosDeviceUpdateRequest
+import com.pluxity.safersCollect.v1.devices.enums.DeviceStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/dto/BandDeviceDtos.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/dto/BandDeviceDtos.kt
@@ -1,5 +1,6 @@
 package com.pluxity.safersCollect.v1.devices.dto
 
+import com.pluxity.safersCollect.v1.devices.enums.DeviceStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/dto/GasDeviceDtos.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/dto/GasDeviceDtos.kt
@@ -1,9 +1,8 @@
 package com.pluxity.safersCollect.v1.devices.dto
 
+import com.pluxity.safersCollect.v1.devices.enums.DeviceStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-
-enum class DeviceStatus { ACTIVE, OFFLINE }
 
 @Schema(description = "3D 모델 로컬 좌표")
 data class InstallLocal(

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/dto/SosDeviceDtos.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/dto/SosDeviceDtos.kt
@@ -1,5 +1,6 @@
 package com.pluxity.safersCollect.v1.devices.dto
 
+import com.pluxity.safersCollect.v1.devices.enums.DeviceStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/enums/DeviceStatus.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/devices/enums/DeviceStatus.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.v1.devices.enums
+
+enum class DeviceStatus { ACTIVE, OFFLINE }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/dto/EventResponse.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/dto/EventResponse.kt
@@ -20,8 +20,8 @@ data class EventResponse(
     val category: EventCategory,
     @field:Schema(description = "이벤트 유형", example = "NO_HELMET")
     val type: EventType,
-    @field:Schema(description = "추적 ID", example = "12345")
-    val trackId: Long,
+    @field:Schema(description = "추적 ID", example = "12345", nullable = true)
+    val trackId: Long?,
     @field:Schema(description = "이벤트명", example = "헬멧 미착용 감지")
     val name: String,
     @field:Schema(description = "신뢰도 (0.0 ~ 1.0)", example = "0.95")

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/dto/EventResponse.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/dto/EventResponse.kt
@@ -3,12 +3,14 @@ package com.pluxity.safers.event.dto
 import com.pluxity.common.file.dto.FileResponse
 import com.pluxity.safers.event.entity.Event
 import com.pluxity.safers.event.entity.EventCategory
+import com.pluxity.safers.event.entity.EventSeverity
+import com.pluxity.safers.event.entity.EventSource
 import com.pluxity.safers.event.entity.EventType
 import com.pluxity.safers.site.dto.SiteResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
-@Schema(description = "이벤트 응답")
+@Schema(description = "이벤트 응답 (CCTV + SAFETY 통합)")
 data class EventResponse(
     @field:Schema(description = "이벤트 ID", example = "1")
     val id: Long,
@@ -20,20 +22,38 @@ data class EventResponse(
     val category: EventCategory,
     @field:Schema(description = "이벤트 유형", example = "NO_HELMET")
     val type: EventType,
-    @field:Schema(description = "추적 ID", example = "12345", nullable = true)
+    @field:Schema(description = "추적 ID (CCTV 전용)", example = "12345", nullable = true)
     val trackId: Long?,
     @field:Schema(description = "이벤트명", example = "헬멧 미착용 감지")
     val name: String,
-    @field:Schema(description = "신뢰도 (0.0 ~ 1.0)", example = "0.95")
+    @field:Schema(description = "신뢰도 (CCTV 전용, 0.0 ~ 1.0)", nullable = true, example = "0.95")
     val confidence: Double?,
     @field:Schema(description = "CCTV 스트림 경로", example = "CCTV-JEJU1-46")
     val path: String,
     @field:Schema(description = "현장 정보")
     val site: SiteResponse?,
-    @field:Schema(description = "스냅샷 파일")
+    @field:Schema(description = "스냅샷 파일 (CCTV)")
     val snapshot: FileResponse?,
-    @field:Schema(description = "영상 파일")
+    @field:Schema(description = "영상 파일 (CCTV)")
     val video: FileResponse?,
+    @field:Schema(description = "심각도 (SAFETY 전용)", nullable = true, example = "CRITICAL")
+    val severity: EventSeverity?,
+    @field:Schema(description = "발생원 (SAFETY 전용)", nullable = true, example = "GAS_SENSOR")
+    val source: EventSource?,
+    @field:Schema(description = "센서 디바이스 ID (SAFETY 가스/SOS)", nullable = true, example = "GAS-MH203-01")
+    val deviceId: String?,
+    @field:Schema(description = "스마트밴드 ID (SAFETY)", nullable = true, example = "BAND-A1B2C3")
+    val bandId: String?,
+    @field:Schema(description = "Raw 위도 (SAFETY)", nullable = true)
+    val lat: Double?,
+    @field:Schema(description = "Raw 경도 (SAFETY)", nullable = true)
+    val lon: Double?,
+    @field:Schema(description = "고도 (m, SAFETY)", nullable = true)
+    val alt: Double?,
+    @field:Schema(description = "수평 정확도 반경 (m, SAFETY)", nullable = true)
+    val accuracyM: Double?,
+    @field:Schema(description = "이벤트 종류별 상세 (SAFETY, JSONB)", nullable = true)
+    val payload: Map<String, Any>?,
 )
 
 fun Event.toResponse(
@@ -54,4 +74,13 @@ fun Event.toResponse(
         site = siteResponse,
         snapshot = snapshotFileResponse ?: FileResponse(),
         video = videoFileResponse ?: FileResponse(),
+        severity = severity,
+        source = source,
+        deviceId = deviceId,
+        bandId = bandId,
+        lat = lat,
+        lon = lon,
+        alt = alt,
+        accuracyM = accuracyM,
+        payload = payload,
     )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/Event.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/Event.kt
@@ -6,6 +6,8 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.time.LocalDateTime
 
 @Entity
@@ -21,10 +23,12 @@ class Event(
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     var type: EventType,
-    @Column(name = "track_id", nullable = false)
-    var trackId: Long,
     @Column(name = "name", nullable = false)
     var name: String,
+    @Column(name = "site_id", nullable = false)
+    var siteId: Long,
+    @Column(name = "track_id")
+    var trackId: Long? = null,
     @Column(name = "bbox")
     var bbox: String? = null,
     @Column(name = "center_x")
@@ -35,8 +39,27 @@ class Event(
     var confidence: Double? = null,
     @Column(name = "path")
     var path: String = "",
-    @Column(name = "site_id", nullable = false)
-    var siteId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", length = 16)
+    var severity: EventSeverity? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", length = 16)
+    var source: EventSource? = null,
+    @Column(name = "device_id", length = 64)
+    var deviceId: String? = null,
+    @Column(name = "band_id", length = 64)
+    var bandId: String? = null,
+    @Column(name = "lat")
+    var lat: Double? = null,
+    @Column(name = "lon")
+    var lon: Double? = null,
+    @Column(name = "alt")
+    var alt: Double? = null,
+    @Column(name = "accuracy_m")
+    var accuracyM: Double? = null,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "jsonb")
+    var payload: Map<String, Any>? = null,
 ) : IdentityIdEntity() {
     @Column(name = "snapshot_file_id")
     var snapshotFileId: Long? = null

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventCategory.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventCategory.kt
@@ -5,4 +5,5 @@ enum class EventCategory(
 ) {
     DETECTION("객체탐지"),
     ROI("영역/경계선 이벤트"),
+    SAFETY("안전 사건"),
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventSeverity.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventSeverity.kt
@@ -1,0 +1,9 @@
+package com.pluxity.safers.event.entity
+
+enum class EventSeverity(
+    val displayName: String,
+) {
+    INFO("정보"),
+    WARNING("경고"),
+    CRITICAL("심각"),
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventSource.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventSource.kt
@@ -1,0 +1,9 @@
+package com.pluxity.safers.event.entity
+
+enum class EventSource(
+    val displayName: String,
+) {
+    GAS_SENSOR("유해가스 센서"),
+    SOS_DEVICE("SOS 디바이스"),
+    SMART_BAND("스마트밴드"),
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventType.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/entity/EventType.kt
@@ -12,4 +12,9 @@ enum class EventType(
     INTRUSION(EventCategory.ROI, "영역 침입"),
     EXIT(EventCategory.ROI, "영역 이탈"),
     LINE_CROSSING(EventCategory.ROI, "경계선 통과"),
+    GAS_THRESHOLD_EXCEEDED(EventCategory.SAFETY, "가스 임계 초과"),
+    SOS_TRIGGERED(EventCategory.SAFETY, "SOS 긴급호출"),
+    BAND_VITAL_ABNORMAL(EventCategory.SAFETY, "밴드 생체신호 이상"),
+    BAND_FALL_DETECTED(EventCategory.SAFETY, "밴드 낙상 감지"),
+    BAND_OFFLINE(EventCategory.SAFETY, "밴드 통신두절"),
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/CctvEventCreated.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/CctvEventCreated.kt
@@ -2,6 +2,6 @@ package com.pluxity.safers.event.listener
 
 import com.pluxity.safers.event.dto.EventResponse
 
-data class EventVideoRegistered(
+data class CctvEventCreated(
     val eventResponse: EventResponse,
 )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/CctvEventVideoRegistered.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/CctvEventVideoRegistered.kt
@@ -2,6 +2,6 @@ package com.pluxity.safers.event.listener
 
 import com.pluxity.safers.event.dto.EventResponse
 
-data class EventCreated(
+data class CctvEventVideoRegistered(
     val eventResponse: EventResponse,
 )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/EventListener.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/EventListener.kt
@@ -12,13 +12,19 @@ class EventListener(
 ) {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun handleEventCreated(event: EventCreated) {
-        stompMessageSender.sendEventCreated(event.eventResponse)
+    fun handleCctvEventCreated(event: CctvEventCreated) {
+        stompMessageSender.sendCctvEventCreated(event.eventResponse)
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun handleEventVideoRegistered(event: EventVideoRegistered) {
-        stompMessageSender.sendEventVideoRegistered(event.eventResponse)
+    fun handleCctvEventVideoRegistered(event: CctvEventVideoRegistered) {
+        stompMessageSender.sendCctvEventVideoRegistered(event.eventResponse)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleSafetyEventCreated(event: SafetyEventCreated) {
+        stompMessageSender.sendSafetyEventCreated(event.eventResponse)
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/SafetyEventCreated.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/listener/SafetyEventCreated.kt
@@ -1,0 +1,7 @@
+package com.pluxity.safers.event.listener
+
+import com.pluxity.safers.ingest.dto.SafetyEventResponse
+
+data class SafetyEventCreated(
+    val eventResponse: SafetyEventResponse,
+)

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/event/service/EventService.kt
@@ -10,8 +10,8 @@ import com.pluxity.safers.event.dto.EventCreateRequest
 import com.pluxity.safers.event.dto.EventResponse
 import com.pluxity.safers.event.dto.toResponse
 import com.pluxity.safers.event.entity.Event
-import com.pluxity.safers.event.listener.EventCreated
-import com.pluxity.safers.event.listener.EventVideoRegistered
+import com.pluxity.safers.event.listener.CctvEventCreated
+import com.pluxity.safers.event.listener.CctvEventVideoRegistered
 import com.pluxity.safers.event.repository.EventRepository
 import com.pluxity.safers.global.constant.SafersErrorCode
 import com.pluxity.safers.llm.dto.EventFilterCriteria
@@ -66,7 +66,7 @@ class EventService(
 
         val fileResponse = fileService.getFileResponse(snapshotFileId)
         val siteResponse = siteRepository.findByIdOrNull(siteId)?.toResponse(null)
-        eventPublisher.publishEvent(EventCreated(savedEvent.toResponse(fileResponse, siteResponse = siteResponse)))
+        eventPublisher.publishEvent(CctvEventCreated(savedEvent.toResponse(fileResponse, siteResponse = siteResponse)))
     }
 
     @Transactional
@@ -85,7 +85,7 @@ class EventService(
             val snapshotFileResponse = fileService.getFileResponse(event.snapshotFileId)
             val videoFileResponse = fileService.getFileResponse(it)
             val siteResponse = siteRepository.findByIdOrNull(event.siteId)?.toResponse(null)
-            eventPublisher.publishEvent(EventVideoRegistered(event.toResponse(snapshotFileResponse, videoFileResponse, siteResponse)))
+            eventPublisher.publishEvent(CctvEventVideoRegistered(event.toResponse(snapshotFileResponse, videoFileResponse, siteResponse)))
         }
     }
 

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/constant/SafersErrorCode.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/constant/SafersErrorCode.kt
@@ -19,6 +19,8 @@ enum class SafersErrorCode(
     PLAYBACK_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "재생 요청에 대한 응답을 받지 못했습니다."),
     NOT_FOUND_DEVICE(HttpStatus.NOT_FOUND, "ID가 %s인 디바이스를 찾을 수 없습니다."),
     DUPLICATE_DEVICE(HttpStatus.CONFLICT, "ID가 %s인 디바이스가 이미 존재합니다."),
+    DUPLICATE_EVENT(HttpStatus.CONFLICT, "ID가 %s인 이벤트가 이미 존재합니다."),
+    INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, "안전 이벤트 ingest 에 허용되지 않는 EventType 입니다: %s"),
     ;
 
     override fun getHttpStatus(): HttpStatus = httpStatus

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/messaging/MessageHandler.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/messaging/MessageHandler.kt
@@ -13,13 +13,13 @@ class MessageHandler(
     fun testEventCreated(
         @Payload payload: EventResponse,
     ) {
-        messageSender.sendEventCreated(payload)
+        messageSender.sendCctvEventCreated(payload)
     }
 
     @MessageMapping("/test/event-video-registered")
     fun testEventVideoRegistered(
         @Payload payload: EventResponse,
     ) {
-        messageSender.sendEventVideoRegistered(payload)
+        messageSender.sendCctvEventVideoRegistered(payload)
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/global/messaging/StompMessageSender.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/global/messaging/StompMessageSender.kt
@@ -1,6 +1,7 @@
 package com.pluxity.safers.global.messaging
 
 import com.pluxity.safers.event.dto.EventResponse
+import com.pluxity.safers.ingest.dto.SafetyEventResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.springwolf.bindings.stomp.annotations.StompAsyncOperationBinding
 import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
@@ -15,35 +16,50 @@ class StompMessageSender(
     private val messageTemplate: SimpMessagingTemplate,
 ) {
     companion object {
-        const val TOPIC_EVENTS: String = "/topic/events"
-        const val TOPIC_EVENT_VIDEOS: String = "/topic/event-videos"
+        const val TOPIC_CCTV_EVENTS: String = "/topic/events"
+        const val TOPIC_CCTV_EVENT_VIDEOS: String = "/topic/event-videos"
+        const val TOPIC_SAFETY_EVENTS: String = "/topic/safety-events"
     }
 
     @AsyncPublisher(
         operation =
             AsyncOperation(
-                channelName = TOPIC_EVENTS,
-                description = "이벤트 생성 시 전체 사용자에게 브로드캐스트",
+                channelName = TOPIC_CCTV_EVENTS,
+                description = "CCTV 이벤트 생성 시 전체 사용자에게 브로드캐스트",
                 payloadType = EventResponse::class,
             ),
     )
     @StompAsyncOperationBinding
-    fun sendEventCreated(payload: EventResponse) {
-        log.info { "Broadcasting event created to all users: ${payload.eventId}" }
-        messageTemplate.convertAndSend(TOPIC_EVENTS, payload)
+    fun sendCctvEventCreated(payload: EventResponse) {
+        log.info { "Broadcasting CCTV event created to all users: ${payload.eventId}" }
+        messageTemplate.convertAndSend(TOPIC_CCTV_EVENTS, payload)
     }
 
     @AsyncPublisher(
         operation =
             AsyncOperation(
-                channelName = TOPIC_EVENT_VIDEOS,
-                description = "이벤트 영상 등록 시 전체 사용자에게 브로드캐스트",
+                channelName = TOPIC_CCTV_EVENT_VIDEOS,
+                description = "CCTV 이벤트 영상 등록 시 전체 사용자에게 브로드캐스트",
                 payloadType = EventResponse::class,
             ),
     )
     @StompAsyncOperationBinding
-    fun sendEventVideoRegistered(payload: EventResponse) {
-        log.info { "Broadcasting event video registered to all users: ${payload.eventId}" }
-        messageTemplate.convertAndSend(TOPIC_EVENT_VIDEOS, payload)
+    fun sendCctvEventVideoRegistered(payload: EventResponse) {
+        log.info { "Broadcasting CCTV event video registered to all users: ${payload.eventId}" }
+        messageTemplate.convertAndSend(TOPIC_CCTV_EVENT_VIDEOS, payload)
+    }
+
+    @AsyncPublisher(
+        operation =
+            AsyncOperation(
+                channelName = TOPIC_SAFETY_EVENTS,
+                description = "안전 이벤트(가스/SOS/밴드) 생성 시 전체 사용자에게 브로드캐스트",
+                payloadType = SafetyEventResponse::class,
+            ),
+    )
+    @StompAsyncOperationBinding
+    fun sendSafetyEventCreated(payload: SafetyEventResponse) {
+        log.info { "Broadcasting safety event created to all users: ${payload.eventId}" }
+        messageTemplate.convertAndSend(TOPIC_SAFETY_EVENTS, payload)
     }
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/controller/DeviceController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/controller/DeviceController.kt
@@ -4,9 +4,9 @@ import com.pluxity.common.core.response.DataResponseBody
 import com.pluxity.common.core.response.ErrorResponseBody
 import com.pluxity.safers.ingest.dto.DeviceCreateRequest
 import com.pluxity.safers.ingest.dto.DeviceResponse
-import com.pluxity.safers.ingest.dto.DeviceStatus
-import com.pluxity.safers.ingest.dto.DeviceType
 import com.pluxity.safers.ingest.dto.DeviceUpdateRequest
+import com.pluxity.safers.ingest.enums.DeviceStatus
+import com.pluxity.safers.ingest.enums.DeviceType
 import com.pluxity.safers.ingest.service.DeviceService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/controller/EventIngestController.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/controller/EventIngestController.kt
@@ -3,6 +3,8 @@ package com.pluxity.safers.ingest.controller
 import com.pluxity.common.core.response.DataResponseBody
 import com.pluxity.common.core.response.ErrorResponseBody
 import com.pluxity.safers.ingest.dto.EventIngestRequest
+import com.pluxity.safers.ingest.dto.SafetyEventResponse
+import com.pluxity.safers.ingest.service.SafetyEventIngestService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -19,23 +21,25 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/sites/{siteId}/events")
-@Tag(name = "Ingest - Events", description = "수집모듈로부터 안전 사건 수신 (X-Api-Key 인증). siteId 는 URL path. 기존 /events 조회 API와는 다름")
-class EventIngestController {
+@Tag(name = "Ingest - Safety Events", description = "수집모듈로부터 안전 사건(가스/SOS/밴드) 수신. siteId 는 URL path. 기존 /events 조회 API 와는 다름")
+class EventIngestController(
+    private val safetyEventIngestService: SafetyEventIngestService,
+) {
     @Operation(
-        summary = "이벤트 적재",
-        description = "수신 즉시 PostgreSQL 동기 INSERT 후 200 응답. payload는 JSONB로 저장.",
+        summary = "안전 이벤트 적재",
+        description = "수신 즉시 PostgreSQL events 테이블에 category=SAFETY 로 INSERT 하고, STOMP /topic/safety-events 로 브로드캐스트.",
     )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "정상 접수"),
             ApiResponse(
                 responseCode = "400",
-                description = "스키마/검증 실패",
+                description = "스키마/검증 실패 또는 EventType 이 SAFETY 카테고리가 아님",
                 content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
             ),
             ApiResponse(
-                responseCode = "401",
-                description = "API Key 없음/무효",
+                responseCode = "409",
+                description = "동일 eventId 중복",
                 content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
             ),
         ],
@@ -44,8 +48,6 @@ class EventIngestController {
     fun ingest(
         @PathVariable siteId: Long,
         @Valid @RequestBody request: EventIngestRequest,
-    ): ResponseEntity<DataResponseBody<Unit>> {
-        // TODO: PostgreSQL INSERT (site_id 컬럼은 path 값) + NOTIFY safety_event
-        return ResponseEntity.ok(DataResponseBody(Unit))
-    }
+    ): ResponseEntity<DataResponseBody<SafetyEventResponse>> =
+        ResponseEntity.ok(DataResponseBody(safetyEventIngestService.ingest(siteId, request)))
 }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/DeviceDtos.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/DeviceDtos.kt
@@ -1,13 +1,11 @@
 package com.pluxity.safers.ingest.dto
 
 import com.pluxity.safers.ingest.entity.Device
+import com.pluxity.safers.ingest.enums.DeviceStatus
+import com.pluxity.safers.ingest.enums.DeviceType
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
-
-enum class DeviceType { GAS, BAND, SOS }
-
-enum class DeviceStatus { ACTIVE, OFFLINE }
 
 @Schema(description = "통합 디바이스 등록 요청 (type 디스크리미네이터 + metadata jsonb). siteId 는 URL path.")
 data class DeviceCreateRequest(

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/EventIngestDtos.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/EventIngestDtos.kt
@@ -1,16 +1,19 @@
 package com.pluxity.safers.ingest.dto
 
+import com.pluxity.safers.event.entity.EventSeverity
+import com.pluxity.safers.event.entity.EventSource
+import com.pluxity.safers.event.entity.EventType
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDateTime
 
-@Schema(description = "정규화 이벤트 envelope")
+@Schema(description = "정규화 안전 이벤트 envelope (가스/SOS/스마트밴드)")
 data class EventIngestRequest(
     @field:NotBlank
     @field:Schema(example = "GAS-EVT-20260424-0001")
     val eventId: String,
-    @field:Schema(example = "GAS_THRESHOLD_EXCEEDED")
-    val eventType: EventTypeKind,
+    @field:Schema(description = "EventCategory.SAFETY 인 EventType 만 허용", example = "GAS_THRESHOLD_EXCEEDED")
+    val eventType: EventType,
     val severity: EventSeverity,
     val source: EventSource,
     @field:Schema(example = "2026-04-24T10:15:30")
@@ -28,18 +31,7 @@ data class EventIngestRequest(
 @Schema(description = "기기가 측정 가능한 raw 위치")
 data class RawPosition(
     val lat: Double,
-    val lng: Double,
-    @field:Schema(nullable = true) val accuracyM: Double? = null,
+    val lon: Double,
+    @field:Schema(description = "고도 (m, GPS 측정값)", nullable = true) val alt: Double? = null,
+    @field:Schema(description = "수평 정확도 반경 (m)", nullable = true) val accuracyM: Double? = null,
 )
-
-enum class EventTypeKind {
-    GAS_THRESHOLD_EXCEEDED,
-    SOS_TRIGGERED,
-    BAND_VITAL_ABNORMAL,
-    BAND_FALL_DETECTED,
-    BAND_OFFLINE,
-}
-
-enum class EventSeverity { INFO, WARNING, CRITICAL }
-
-enum class EventSource { GAS_SENSOR, SOS_DEVICE, SMART_BAND }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/SafetyEventResponse.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/SafetyEventResponse.kt
@@ -1,0 +1,61 @@
+package com.pluxity.safers.ingest.dto
+
+import com.pluxity.safers.event.entity.Event
+import com.pluxity.safers.event.entity.EventSeverity
+import com.pluxity.safers.event.entity.EventSource
+import com.pluxity.safers.event.entity.EventType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "안전 이벤트 응답 (STOMP 브로드캐스트 + ingest API 응답 공용)")
+data class SafetyEventResponse(
+    @field:Schema(description = "내부 ID", example = "1024")
+    val id: Long,
+    @field:Schema(description = "외부 시스템 이벤트 ID", example = "GAS-EVT-20260424-0001")
+    val eventId: String,
+    @field:Schema(description = "이벤트 유형", example = "GAS_THRESHOLD_EXCEEDED")
+    val eventType: EventType,
+    @field:Schema(description = "이벤트 이름", example = "가스 임계 초과")
+    val name: String,
+    @field:Schema(description = "심각도", example = "CRITICAL")
+    val severity: EventSeverity,
+    @field:Schema(description = "발생원", example = "GAS_SENSOR")
+    val source: EventSource,
+    @field:Schema(description = "발생 시간", example = "2026-04-24T10:15:30")
+    val occurredAt: LocalDateTime,
+    @field:Schema(description = "사이트 ID", example = "42")
+    val siteId: Long,
+    @field:Schema(description = "센서 디바이스 ID (가스/SOS)", example = "GAS-MH203-01", nullable = true)
+    val deviceId: String?,
+    @field:Schema(description = "스마트밴드 ID", example = "BAND-A1B2C3", nullable = true)
+    val bandId: String?,
+    @field:Schema(description = "Raw 위도", nullable = true)
+    val lat: Double?,
+    @field:Schema(description = "Raw 경도", nullable = true)
+    val lon: Double?,
+    @field:Schema(description = "고도 (m, GPS 측정값)", nullable = true)
+    val alt: Double?,
+    @field:Schema(description = "수평 정확도 반경 (m)", nullable = true)
+    val accuracyM: Double?,
+    @field:Schema(description = "이벤트 종류별 상세 (JSONB)", nullable = true)
+    val payload: Map<String, Any>?,
+)
+
+fun Event.toSafetyResponse(): SafetyEventResponse =
+    SafetyEventResponse(
+        id = requiredId,
+        eventId = eventId,
+        eventType = type,
+        name = name,
+        severity = requireNotNull(severity) { "severity must be set for SAFETY events" },
+        source = requireNotNull(source) { "source must be set for SAFETY events" },
+        occurredAt = eventTimestamp,
+        siteId = siteId,
+        deviceId = deviceId,
+        bandId = bandId,
+        lat = lat,
+        lon = lon,
+        alt = alt,
+        accuracyM = accuracyM,
+        payload = payload,
+    )

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/TelemetryRequest.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/dto/TelemetryRequest.kt
@@ -1,5 +1,6 @@
 package com.pluxity.safers.ingest.dto
 
+import com.pluxity.safers.ingest.enums.SourceType
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
@@ -31,5 +32,3 @@ data class TelemetryRequest(
     @field:Schema(description = "InfluxDB field (값)", example = "{\"value\":3.1,\"unit\":\"PPM\",\"battery\":87}")
     val fields: Map<String, Any> = emptyMap(),
 )
-
-enum class SourceType { GAS, BAND, SOS }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/entity/Device.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/entity/Device.kt
@@ -1,8 +1,8 @@
 package com.pluxity.safers.ingest.entity
 
 import com.pluxity.common.core.entity.IdentityIdEntity
-import com.pluxity.safers.ingest.dto.DeviceStatus
-import com.pluxity.safers.ingest.dto.DeviceType
+import com.pluxity.safers.ingest.enums.DeviceStatus
+import com.pluxity.safers.ingest.enums.DeviceType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/enums/DeviceStatus.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/enums/DeviceStatus.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safers.ingest.enums
+
+enum class DeviceStatus { ACTIVE, OFFLINE }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/enums/DeviceType.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/enums/DeviceType.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safers.ingest.enums
+
+enum class DeviceType { GAS, BAND, SOS }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/enums/SourceType.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/enums/SourceType.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safers.ingest.enums
+
+enum class SourceType { GAS, BAND, SOS }

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/repository/DeviceRepository.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/repository/DeviceRepository.kt
@@ -1,8 +1,8 @@
 package com.pluxity.safers.ingest.repository
 
-import com.pluxity.safers.ingest.dto.DeviceStatus
-import com.pluxity.safers.ingest.dto.DeviceType
 import com.pluxity.safers.ingest.entity.Device
+import com.pluxity.safers.ingest.enums.DeviceStatus
+import com.pluxity.safers.ingest.enums.DeviceType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/DeviceService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/DeviceService.kt
@@ -4,11 +4,11 @@ import com.pluxity.common.core.exception.CustomException
 import com.pluxity.safers.global.constant.SafersErrorCode
 import com.pluxity.safers.ingest.dto.DeviceCreateRequest
 import com.pluxity.safers.ingest.dto.DeviceResponse
-import com.pluxity.safers.ingest.dto.DeviceStatus
-import com.pluxity.safers.ingest.dto.DeviceType
 import com.pluxity.safers.ingest.dto.DeviceUpdateRequest
 import com.pluxity.safers.ingest.dto.toResponse
 import com.pluxity.safers.ingest.entity.Device
+import com.pluxity.safers.ingest.enums.DeviceStatus
+import com.pluxity.safers.ingest.enums.DeviceType
 import com.pluxity.safers.ingest.repository.DeviceRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/SafetyEventIngestService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/SafetyEventIngestService.kt
@@ -1,0 +1,73 @@
+package com.pluxity.safers.ingest.service
+
+import com.pluxity.common.core.exception.CustomException
+import com.pluxity.safers.event.entity.Event
+import com.pluxity.safers.event.entity.EventCategory
+import com.pluxity.safers.event.listener.SafetyEventCreated
+import com.pluxity.safers.event.repository.EventRepository
+import com.pluxity.safers.global.constant.SafersErrorCode
+import com.pluxity.safers.ingest.dto.EventIngestRequest
+import com.pluxity.safers.ingest.dto.SafetyEventResponse
+import com.pluxity.safers.ingest.dto.toSafetyResponse
+import com.pluxity.safers.ingest.repository.DeviceRepository
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class SafetyEventIngestService(
+    private val eventRepository: EventRepository,
+    private val deviceRepository: DeviceRepository,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    @Transactional
+    fun ingest(
+        siteId: Long,
+        request: EventIngestRequest,
+    ): SafetyEventResponse {
+        if (request.eventType.category != EventCategory.SAFETY) {
+            throw CustomException(SafersErrorCode.INVALID_EVENT_TYPE, request.eventType.name)
+        }
+        if (eventRepository.findByEventId(request.eventId) != null) {
+            throw CustomException(SafersErrorCode.DUPLICATE_EVENT, request.eventId)
+        }
+
+        val event =
+            Event(
+                eventId = request.eventId,
+                eventTimestamp = request.occurredAt,
+                category = EventCategory.SAFETY,
+                type = request.eventType,
+                name = request.eventType.displayName,
+                siteId = siteId,
+                severity = request.severity,
+                source = request.source,
+                deviceId = request.deviceId,
+                bandId = request.bandId,
+                lat = request.rawPosition?.lat,
+                lon = request.rawPosition?.lon,
+                alt = request.rawPosition?.alt,
+                accuracyM = request.rawPosition?.accuracyM,
+                payload = request.payload,
+            )
+        val saved = eventRepository.save(event)
+
+        touchDeviceLastSeen(siteId, request.deviceId, request.bandId, request.occurredAt)
+
+        val response = saved.toSafetyResponse()
+        eventPublisher.publishEvent(SafetyEventCreated(response))
+        return response
+    }
+
+    private fun touchDeviceLastSeen(
+        siteId: Long,
+        deviceId: String?,
+        bandId: String?,
+        seenAt: java.time.LocalDateTime,
+    ) {
+        val key = deviceId ?: bandId ?: return
+        val device = deviceRepository.findByDeviceIdAndSiteId(key, siteId) ?: return
+        device.lastSeenAt = seenAt
+    }
+}

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/SafetyEventIngestService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/SafetyEventIngestService.kt
@@ -30,9 +30,6 @@ class SafetyEventIngestService(
         if (request.eventType.category != EventCategory.SAFETY) {
             throw CustomException(SafersErrorCode.INVALID_EVENT_TYPE, request.eventType.name)
         }
-        if (eventRepository.findByEventId(request.eventId) != null) {
-            throw CustomException(SafersErrorCode.DUPLICATE_EVENT, request.eventId)
-        }
 
         val event =
             Event(
@@ -56,7 +53,7 @@ class SafetyEventIngestService(
             try {
                 eventRepository.save(event)
             } catch (_: DataIntegrityViolationException) {
-                // uk_events_event_id 등 unique 제약 — 사전 체크와 save 사이의 race 케이스
+                // uk_events_event_id 위반 — 동일 eventId 중복 (재시도 또는 동시 요청)
                 throw CustomException(SafersErrorCode.DUPLICATE_EVENT, request.eventId)
             }
 

--- a/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/SafetyEventIngestService.kt
+++ b/apps/safers/src/main/kotlin/com/pluxity/safers/ingest/service/SafetyEventIngestService.kt
@@ -11,6 +11,7 @@ import com.pluxity.safers.ingest.dto.SafetyEventResponse
 import com.pluxity.safers.ingest.dto.toSafetyResponse
 import com.pluxity.safers.ingest.repository.DeviceRepository
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -51,7 +52,13 @@ class SafetyEventIngestService(
                 accuracyM = request.rawPosition?.accuracyM,
                 payload = request.payload,
             )
-        val saved = eventRepository.save(event)
+        val saved =
+            try {
+                eventRepository.save(event)
+            } catch (_: DataIntegrityViolationException) {
+                // uk_events_event_id 등 unique 제약 — 사전 체크와 save 사이의 race 케이스
+                throw CustomException(SafersErrorCode.DUPLICATE_EVENT, request.eventId)
+            }
 
         touchDeviceLastSeen(siteId, request.deviceId, request.bandId, request.occurredAt)
 

--- a/apps/safers/src/main/resources/db/migration/V20260430_001__extend_events_for_safety.sql
+++ b/apps/safers/src/main/resources/db/migration/V20260430_001__extend_events_for_safety.sql
@@ -1,0 +1,23 @@
+-- 안전 이벤트(가스/SOS/스마트밴드)를 기존 events 테이블에 통합 적재.
+-- category=SAFETY 디스크리미네이터로 CCTV(category=DETECTION/ROI) 와 구분.
+-- 모든 DDL 은 idempotent — 부분 적용된 환경에서도 재실행 안전.
+
+-- 안전 이벤트는 trackId 가 없으므로 NOT NULL 완화 (이미 NULL 허용이면 no-op)
+ALTER TABLE events ALTER COLUMN track_id DROP NOT NULL;
+
+-- 안전 이벤트 전용 컬럼 (CCTV 행은 모두 NULL)
+ALTER TABLE events ADD COLUMN IF NOT EXISTS severity   VARCHAR(16);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS source     VARCHAR(16);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS device_id  VARCHAR(64);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS band_id    VARCHAR(64);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS lat        DOUBLE PRECISION;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS lon        DOUBLE PRECISION;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS alt        DOUBLE PRECISION;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS accuracy_m DOUBLE PRECISION;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS payload    JSONB;
+
+-- 인덱스: partial index 로 CCTV 행 제외해 인덱스 크기 절약
+CREATE INDEX IF NOT EXISTS idx_events_device   ON events (device_id) WHERE device_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_band     ON events (band_id)   WHERE band_id   IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_severity ON events (severity, event_timestamp DESC) WHERE severity IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_payload  ON events USING GIN (payload jsonb_path_ops) WHERE payload IS NOT NULL;

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/event/dto/DummyDTOs.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/event/dto/DummyDTOs.kt
@@ -31,6 +31,15 @@ fun dummyEventResponse(
         site = null,
         snapshot = snapshot,
         video = video,
+        severity = null,
+        source = null,
+        deviceId = null,
+        bandId = null,
+        lat = null,
+        lon = null,
+        alt = null,
+        accuracyM = null,
+        payload = null,
     )
 
 fun dummyEventCreateRequest(

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventServiceTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/event/service/EventServiceTest.kt
@@ -8,7 +8,7 @@ import com.pluxity.safers.cctv.service.CctvSiteCache
 import com.pluxity.safers.event.dto.dummyEventCreateRequest
 import com.pluxity.safers.event.entity.Event
 import com.pluxity.safers.event.entity.dummyEvent
-import com.pluxity.safers.event.listener.EventCreated
+import com.pluxity.safers.event.listener.CctvEventCreated
 import com.pluxity.safers.event.repository.EventRepository
 import com.pluxity.safers.global.constant.SafersErrorCode
 import com.pluxity.safers.llm.EventLlmClient
@@ -74,8 +74,8 @@ class EventServiceTest :
                     verify { fileService.finalizeUpload(snapshotFileId, "events/1/") }
                 }
 
-                Then("EventCreated 이벤트가 발행된다") {
-                    verify { eventPublisher.publishEvent(any<EventCreated>()) }
+                Then("CctvEventCreated 이벤트가 발행된다") {
+                    verify { eventPublisher.publishEvent(any<CctvEventCreated>()) }
                 }
             }
 

--- a/apps/safers/src/test/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriterTest.kt
+++ b/apps/safers/src/test/kotlin/com/pluxity/safers/ingest/persistence/influx/InfluxTelemetryWriterTest.kt
@@ -3,8 +3,8 @@ package com.pluxity.safers.ingest.persistence.influx
 import com.influxdb.client.WriteApi
 import com.influxdb.client.write.Point
 import com.pluxity.safers.ingest.config.InfluxProperties
-import com.pluxity.safers.ingest.dto.SourceType
 import com.pluxity.safers.ingest.dto.TelemetryRequest
+import com.pluxity.safers.ingest.enums.SourceType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain


### PR DESCRIPTION
## Summary

- `apps/safers-collect` 신규 모듈 (현장 수집 게이트웨이 — `:common:*` / safers 의존 없음)
- 중앙(`apps/safers`) 통합 ingest API: `/v1/sites/{siteId}/{telemetry,events,devices}`, 디바이스 CRUD 영속화, X-Api-Key 도입 전까지 `permitAll`
- safers Kafka 제거 → `ApplicationEventPublisher + @Async @TransactionalEventListener` 로 전환
- **안전 이벤트 ingest 구현** (가스/SOS/스마트밴드)
  - 기존 `events` 테이블에 `category=SAFETY` 디스크리미네이터로 통합 저장 (별도 `safety_event` 테이블 안 만듦 — 운영자 UI 통합 피드 + STOMP 단일 토픽 의도)
  - Flyway `V20260430_001`: `track_id` NULLABLE 완화, 안전 컬럼 9개(`severity, source, device_id, band_id, lat, lon, alt, accuracy_m, payload jsonb`) 추가, partial 인덱스 4개. 모든 DDL idempotent
  - `EventCategory.SAFETY` + `EventType` 5종 + `EventSeverity` / `EventSource` enum 추가
  - `SafetyEventIngestService`: events INSERT, 동일 site 의 디바이스 `lastSeenAt` 자동 갱신, `INVALID_EVENT_TYPE`/`DUPLICATE_EVENT` 에러 코드. DB unique 제약 위반을 `DataIntegrityViolationException` 으로 받아 409 변환 (concurrent race 안전)
- CCTV ↔ 안전 이벤트 분리
  - `EventCreated/EventVideoRegistered → CctvEventCreated/CctvEventVideoRegistered` 리네임
  - `SafetyEventCreated` 신규 publish event
  - `EventListener` 단일 빈에서 CCTV 2개 + Safety 1개 핸들러 처리
  - STOMP: `sendCctvEventCreated`, `sendCctvEventVideoRegistered`, `sendSafetyEventCreated`. CCTV 토픽 wire 경로(`/topic/events`, `/topic/event-videos`) 호환 유지, 안전 이벤트는 신규 `/topic/safety-events`
  - `EventResponse` 에 안전 컬럼 9개 추가 — `GET /events` 통합 피드가 SAFETY 행도 의미있게 반환
- DTO 파일에 섞여있던 enum 들을 `enums/` 서브패키지로 분리 (양 모듈)
  - `safers/ingest/enums/{SourceType,DeviceType,DeviceStatus}`
  - `safers-collect/v1/collect/enums/*` (8개), `v1/devices/enums/DeviceStatus`
  - `TelemetryDtos.kt → TelemetryRequest.kt` (단일 클래스 파일명 규칙)

## 명세

`WORKER_SAFETY_API_DRAFT.md` (§7.2 이벤트수집, §9.2 통합 events 테이블, §8 Enum 정의 참조).

## 보류 (별도 PR)

- X-Api-Key Filter 도입
- TelemetryController InfluxDB writer 실제 구현
- safers-collect → 중앙 forwarder 구현 (이때 collect 측 `RawPosition.lng → lon` + `alt` 정합성 맞추기)
- `SafetyEventIngestServiceTest` (코드리뷰에서 지적된 테스트 갭)
- `EventService.findAll` 의 SAFETY 행 응답 검증 (snapshot/video FileResponse 가 빈 객체로 전송되는데 프론트 호환 확인 필요)

## Test plan

- [ ] `./gradlew :apps:safers:test :apps:safers-collect:test` 통과 확인
- [ ] DB 마이그레이션 적용 (V20260430_001) — 기존 CCTV 행이 `track_id NULL` 허용 후에도 정상 조회되는지
- [ ] `POST /v1/sites/{siteId}/events` 동작 확인 — Swagger UI 에서 GAS_THRESHOLD_EXCEEDED / SOS_TRIGGERED / BAND_VITAL_ABNORMAL 각각
- [ ] 동일 `eventId` 중복 요청 → 409 `DUPLICATE_EVENT`
- [ ] CCTV 카테고리 EventType 으로 안전 ingest 시도 → 400 `INVALID_EVENT_TYPE`
- [ ] STOMP `/topic/safety-events` 구독 → 안전 이벤트 수신
- [ ] STOMP `/topic/events` 기존 CCTV 클라이언트 호환
- [ ] `GET /events` 가 CCTV + SAFETY 행 모두 반환, 각자 필드 채워짐
- [ ] 안전 이벤트 ingest 시 동일 site 의 디바이스 `lastSeenAt` 갱신 확인