### PR TITLE
feat: safers-collect telemetry 수집/forward 파이프라인

### DIFF
--- a/apps/safers-collect/build.gradle.kts
+++ b/apps/safers-collect/build.gradle.kts
@@ -15,3 +15,7 @@ configurations.all {
     exclude(group = "org.postgresql", module = "postgresql")
     exclude(group = "com.github.gavlyukovskiy", module = "p6spy-spring-boot-starter")
 }
+
+dependencies {
+    implementation(rootProject.libs.spring.boot.starter.webflux)
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/SafersCollectApplication.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/SafersCollectApplication.kt
@@ -3,7 +3,9 @@ package com.pluxity.safersCollect
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 class SafersCollectApplication

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/SafersCollectApplication.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/SafersCollectApplication.kt
@@ -1,8 +1,10 @@
 package com.pluxity.safersCollect
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 class SafersCollectApplication
 

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/buffer/TelemetryBuffer.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/buffer/TelemetryBuffer.kt
@@ -1,0 +1,28 @@
+package com.pluxity.safersCollect.buffer
+
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import org.springframework.stereotype.Component
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+
+@Component
+class TelemetryBuffer(
+    prop: SafersCollectProperties,
+) {
+    private val queue: BlockingQueue<TelemetryEnvelope> = LinkedBlockingQueue(prop.buffer.inMemoryMax)
+
+    fun enqueueAll(items: Collection<TelemetryEnvelope>) {
+        items.forEach {
+            while (!queue.offer(it)) queue.poll()
+        }
+    }
+
+    fun drain(maxItems: Int): List<TelemetryEnvelope> {
+        val out = ArrayList<TelemetryEnvelope>(maxItems)
+        queue.drainTo(out, maxItems)
+        return out
+    }
+
+    fun size(): Int = queue.size
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
@@ -1,0 +1,12 @@
+package com.pluxity.safersCollect.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "safety-collector")
+data class SafersCollectProperties(
+    val buffer: Buffer,
+) {
+    data class Buffer(
+        val inMemoryMax: Int,
+    )
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
@@ -4,9 +4,26 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "safety-collector")
 data class SafersCollectProperties(
+    val site: Site,
+    val central: Central,
     val buffer: Buffer,
+    val forwarder: Forwarder,
 ) {
+    data class Site(
+        val id: Long,
+    )
+
+    data class Central(
+        val ingestUrl: String,
+        val apiKey: String,
+    )
+
     data class Buffer(
         val inMemoryMax: Int,
+    )
+
+    data class Forwarder(
+        val batchSize: Int,
+        val flushIntervalMs: Long,
     )
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/CentralIngestClient.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/CentralIngestClient.kt
@@ -1,0 +1,33 @@
+package com.pluxity.safersCollect.forwarder
+
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.forwarder.dto.TelemetryBatchRequest
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component
+class CentralIngestClient(
+    private val props: SafersCollectProperties,
+) {
+    private val webClient: WebClient =
+        WebClient
+            .builder()
+            .baseUrl(props.central.ingestUrl)
+            .defaultHeader(API_KEY_HEADER, props.central.apiKey)
+            .build()
+
+    fun postTelemetry(envelopes: List<TelemetryEnvelope>) {
+        webClient
+            .post()
+            .uri("/v1/sites/{siteId}/telemetry", props.site.id)
+            .bodyValue(TelemetryBatchRequest(envelopes))
+            .retrieve()
+            .toBodilessEntity()
+            .block()
+    }
+
+    companion object {
+        private const val API_KEY_HEADER = "X-Api-Key"
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarder.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarder.kt
@@ -1,0 +1,29 @@
+package com.pluxity.safersCollect.forwarder
+
+import com.pluxity.safersCollect.buffer.TelemetryBuffer
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class TelemetryForwarder(
+    private val buffer: TelemetryBuffer,
+    private val client: CentralIngestClient,
+    private val props: SafersCollectProperties,
+) {
+    @Scheduled(fixedDelayString = "\${safety-collector.forwarder.flush-interval-ms}")
+    fun flush() {
+        val batch = buffer.drain(props.forwarder.batchSize)
+        if (batch.isEmpty()) return
+
+        try {
+            client.postTelemetry(batch)
+        } catch (e: Exception) {
+            log.warn(e) { "telemetry forward 실패 — ${batch.size} envelope 재enqueue" }
+            buffer.enqueueAll(batch)
+        }
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/dto/TelemetryBatchRequest.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/dto/TelemetryBatchRequest.kt
@@ -1,0 +1,5 @@
+package com.pluxity.safersCollect.forwarder.dto
+
+data class TelemetryBatchRequest(
+    val samples: List<TelemetryEnvelope>,
+)

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/dto/TelemetryEnvelope.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/dto/TelemetryEnvelope.kt
@@ -1,0 +1,13 @@
+package com.pluxity.safersCollect.forwarder.dto
+
+import com.pluxity.safersCollect.forwarder.enums.SourceType
+import java.time.LocalDateTime
+
+data class TelemetryEnvelope(
+    val sourceType: SourceType,
+    val sourceId: String,
+    val timestamp: LocalDateTime,
+    val measurement: String,
+    val tags: Map<String, String> = emptyMap(),
+    val fields: Map<String, Any> = emptyMap(),
+)

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/enums/SourceType.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/enums/SourceType.kt
@@ -1,0 +1,3 @@
+package com.pluxity.safersCollect.forwarder.enums
+
+enum class SourceType { GAS, BAND, SOS }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/adapter/BandTelemetryAdapter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/adapter/BandTelemetryAdapter.kt
@@ -1,0 +1,53 @@
+package com.pluxity.safersCollect.v1.collect.adapter
+
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.forwarder.enums.SourceType
+import com.pluxity.safersCollect.v1.collect.dto.BandCollectRequest
+import org.springframework.stereotype.Component
+
+@Component
+class BandTelemetryAdapter {
+    companion object {
+        const val BAND_MEASUREMENT = "band_reading"
+        const val BAND_ID = "band_id"
+        const val WEAR_STATE = "wear_state"
+        const val LAT = "lat"
+        const val LNG = "lng"
+        const val ACCURACY_M = "accuracy_m"
+        const val HEART_RATE_BPM = "heart_rate_bpm"
+        const val SPO2 = "spo2"
+        const val BODY_TEMP_C = "body_temp_c"
+        const val STEP = "step"
+        const val BATTERY = "battery"
+    }
+
+    fun toEnvelopes(request: BandCollectRequest): List<TelemetryEnvelope> =
+        request.samples.map { sample ->
+            TelemetryEnvelope(
+                sourceType = SourceType.BAND,
+                sourceId = sample.bandId,
+                timestamp = sample.timestamp,
+                measurement = BAND_MEASUREMENT,
+                tags =
+                    buildMap {
+                        put(BAND_ID, sample.bandId)
+                        sample.wearState?.let { put(WEAR_STATE, it.name) }
+                    },
+                fields =
+                    buildMap {
+                        sample.rawPosition?.let { position ->
+                            put(LAT, position.lat)
+                            put(LNG, position.lng)
+                            position.accuracyM?.let { put(ACCURACY_M, it) }
+                        }
+                        sample.vitals?.let { vital ->
+                            vital.heartRateBpm?.let { put(HEART_RATE_BPM, it) }
+                            vital.spo2?.let { put(SPO2, it) }
+                            vital.bodyTempC?.let { put(BODY_TEMP_C, it) }
+                            vital.step?.let { put(STEP, it) }
+                        }
+                        sample.battery?.let { put(BATTERY, it) }
+                    },
+            )
+        }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/adapter/GasTelemetryAdapter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/adapter/GasTelemetryAdapter.kt
@@ -1,0 +1,43 @@
+package com.pluxity.safersCollect.v1.collect.adapter
+
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.forwarder.enums.SourceType
+import com.pluxity.safersCollect.v1.collect.dto.GasCollectRequest
+import org.springframework.stereotype.Component
+
+@Component
+class GasTelemetryAdapter {
+    companion object {
+        const val GAS_MEASUREMENT = "gas_reading"
+        const val DEVICE_ID = "device_id"
+        const val GAS_UNIT = "unit"
+        const val GAS = "gas"
+        const val GAS_VALUE = "value"
+        const val GAS_BATTERY = "battery"
+        const val GAS_SIGNAL_RSSI = "signal_rssi"
+    }
+
+    fun toEnvelopes(request: GasCollectRequest): List<TelemetryEnvelope> =
+        request.samples.flatMap { sample ->
+            sample.measurements.map { measurement ->
+                TelemetryEnvelope(
+                    sourceId = sample.deviceId,
+                    sourceType = SourceType.GAS,
+                    measurement = GAS_MEASUREMENT,
+                    tags =
+                        mapOf(
+                            DEVICE_ID to sample.deviceId,
+                            GAS_UNIT to measurement.unit.name,
+                            GAS to measurement.gas.name,
+                        ),
+                    fields =
+                        buildMap {
+                            put(GAS_VALUE, measurement.value)
+                            sample.battery?.let { put(GAS_BATTERY, it) }
+                            sample.signalRssi?.let { put(GAS_SIGNAL_RSSI, it) }
+                        },
+                    timestamp = sample.timestamp,
+                )
+            }
+        }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/BandCollectController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/BandCollectController.kt
@@ -16,8 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/collect/band")
 class BandCollectController(
-    val adapter: BandTelemetryAdapter,
-    val buffer: TelemetryBuffer,
+    private val adapter: BandTelemetryAdapter,
+    private val buffer: TelemetryBuffer,
 ) {
     @Operation(summary = "스마트밴드 측정값 수집", description = "위치/체온/심박수/SpO2 등. 1~500건 batch.")
     @PostMapping

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/BandCollectController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/BandCollectController.kt
@@ -1,5 +1,7 @@
 package com.pluxity.safersCollect.v1.collect.controller
 
+import com.pluxity.safersCollect.buffer.TelemetryBuffer
+import com.pluxity.safersCollect.v1.collect.adapter.BandTelemetryAdapter
 import com.pluxity.safersCollect.v1.collect.dto.BandCollectRequest
 import com.pluxity.safersCollect.v1.collect.dto.BandEventRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -13,13 +15,16 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "2. 스마트밴드 수집", description = "근로자 웨어러블 측정값 / 이상 이벤트")
 @RestController
 @RequestMapping("/collect/band")
-class BandCollectController {
+class BandCollectController(
+    val adapter: BandTelemetryAdapter,
+    val buffer: TelemetryBuffer,
+) {
     @Operation(summary = "스마트밴드 측정값 수집", description = "위치/체온/심박수/SpO2 등. 1~500건 batch.")
     @PostMapping
     fun collect(
         @Valid @RequestBody request: BandCollectRequest,
     ) {
-        // TODO
+        buffer.enqueueAll(adapter.toEnvelopes(request))
     }
 
     @Operation(

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/GasCollectController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/GasCollectController.kt
@@ -1,7 +1,6 @@
 package com.pluxity.safersCollect.v1.collect.controller
 
 import com.pluxity.safersCollect.buffer.TelemetryBuffer
-import com.pluxity.safersCollect.forwarder.TelemetryForwarder
 import com.pluxity.safersCollect.v1.collect.adapter.GasTelemetryAdapter
 import com.pluxity.safersCollect.v1.collect.dto.GasCollectRequest
 import com.pluxity.safersCollect.v1.collect.dto.GasEventRequest

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/GasCollectController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/GasCollectController.kt
@@ -1,5 +1,8 @@
 package com.pluxity.safersCollect.v1.collect.controller
 
+import com.pluxity.safersCollect.buffer.TelemetryBuffer
+import com.pluxity.safersCollect.forwarder.TelemetryForwarder
+import com.pluxity.safersCollect.v1.collect.adapter.GasTelemetryAdapter
 import com.pluxity.safersCollect.v1.collect.dto.GasCollectRequest
 import com.pluxity.safersCollect.v1.collect.dto.GasEventRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -13,13 +16,16 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "1. 가스센서 수집", description = "유해가스 측정값 / 임계 초과 이벤트")
 @RestController
 @RequestMapping("/collect/gas")
-class GasCollectController {
+class GasCollectController(
+    private val gasAdapter: GasTelemetryAdapter,
+    private val buffer: TelemetryBuffer,
+) {
     @Operation(summary = "유해가스 측정값 수집", description = "정상 범위 측정값 시계열 적재용. 1~500건 batch.")
     @PostMapping
     fun collect(
         @Valid @RequestBody request: GasCollectRequest,
     ) {
-        // TODO: 어댑터 → 정규화 envelope → buffer enqueue → forwarder
+        buffer.enqueueAll(gasAdapter.toEnvelopes(request))
     }
 
     @Operation(summary = "유해가스 임계 초과 이벤트 수집", description = "임계 초과 시점에만 호출. 동기 처리.")

--- a/apps/safers-collect/src/main/resources/application-local.yml
+++ b/apps/safers-collect/src/main/resources/application-local.yml
@@ -5,3 +5,8 @@ spring:
 logging:
   level:
     com: DEBUG
+
+safety-collector:
+  buffer:
+    in-memory-max: 10000
+

--- a/apps/safers-collect/src/main/resources/application-local.yml
+++ b/apps/safers-collect/src/main/resources/application-local.yml
@@ -7,6 +7,13 @@ logging:
     com: DEBUG
 
 safety-collector:
+  site:
+    id: 42                                         # 이 모듈이 어느 사이트인지 — 중앙 sites.id
+  central:
+    ingest-url: ${CENTRAL_INGEST_URL:http://localhost:8080}
+    api-key: ${INGEST_API_KEY:pluxity}
   buffer:
-    in-memory-max: 10000
-
+    in-memory-max: 10000                            # 백프레셔 임계 (drop oldest)
+  forwarder:
+    batch-size: 100                                 # 한 번에 forward 할 envelope 수
+    flush-interval-ms: 1000                         # @Scheduled fixedDelay (ms)

--- a/apps/safers-collect/src/main/resources/application-prod.yml
+++ b/apps/safers-collect/src/main/resources/application-prod.yml
@@ -7,5 +7,13 @@ logging:
     com: DEBUG
 
 safety-collector:
+  site:
+    id: ${SAFERS_SITE_ID}                           # 사이트별 다름 — 환경변수 필수
+  central:
+    ingest-url: ${CENTRAL_INGEST_URL}
+    api-key: ${INGEST_API_KEY}
   buffer:
     in-memory-max: 10000
+  forwarder:
+    batch-size: 100
+    flush-interval-ms: 1000

--- a/apps/safers-collect/src/main/resources/application-prod.yml
+++ b/apps/safers-collect/src/main/resources/application-prod.yml
@@ -5,3 +5,7 @@ spring:
 logging:
   level:
     com: DEBUG
+
+safety-collector:
+  buffer:
+    in-memory-max: 10000

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/buffer/TelemetryBufferTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/buffer/TelemetryBufferTest.kt
@@ -13,7 +13,14 @@ class TelemetryBufferTest :
 
         fun props(capacity: Int) =
             SafersCollectProperties(
+                site = SafersCollectProperties.Site(id = 0L),
+                central = SafersCollectProperties.Central(ingestUrl = "http://test", apiKey = "test"),
                 buffer = SafersCollectProperties.Buffer(inMemoryMax = capacity),
+                forwarder =
+                    SafersCollectProperties.Forwarder(
+                        batchSize = 100,
+                        flushIntervalMs = 1000,
+                    ),
             )
 
         fun env(id: String) =

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/buffer/TelemetryBufferTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/buffer/TelemetryBufferTest.kt
@@ -1,0 +1,107 @@
+package com.pluxity.safersCollect.buffer
+
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.forwarder.enums.SourceType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class TelemetryBufferTest :
+    BehaviorSpec({
+
+        fun props(capacity: Int) =
+            SafersCollectProperties(
+                buffer = SafersCollectProperties.Buffer(inMemoryMax = capacity),
+            )
+
+        fun env(id: String) =
+            TelemetryEnvelope(
+                sourceType = SourceType.GAS,
+                sourceId = id,
+                timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                measurement = "gas_reading",
+            )
+
+        Given("빈 buffer") {
+            val buffer = TelemetryBuffer(props(10))
+
+            Then("size 는 0") {
+                buffer.size() shouldBe 0
+            }
+
+            When("drain(5) 호출") {
+                val drained = buffer.drain(5)
+
+                Then("emptyList 반환 — block 안 함") {
+                    drained shouldBe emptyList()
+                }
+            }
+        }
+
+        Given("envelope 5개를 enqueue 한 buffer (capacity 10)") {
+            val buffer = TelemetryBuffer(props(10))
+            buffer.enqueueAll((1..5).map { env("$it") })
+
+            Then("size 는 5") {
+                buffer.size() shouldBe 5
+            }
+
+            When("drain(3) — drain less than size") {
+                val drained = buffer.drain(3)
+
+                Then("oldest 3개를 순서대로 반환 + size 는 2 로 줄어듦") {
+                    drained.map { it.sourceId } shouldBe listOf("1", "2", "3")
+                    buffer.size() shouldBe 2
+                }
+            }
+        }
+
+        Given("envelope 3개를 enqueue 한 buffer (capacity 10)") {
+            val buffer = TelemetryBuffer(props(10))
+            buffer.enqueueAll((1..3).map { env("$it") })
+
+            When("drain(10) — drain more than size") {
+                val drained = buffer.drain(10)
+
+                Then("있는 3개 전부 반환 + size 0 — block 없이 즉시") {
+                    drained shouldHaveSize 3
+                    drained.map { it.sourceId } shouldBe listOf("1", "2", "3")
+                    buffer.size() shouldBe 0
+                }
+            }
+        }
+
+        Given("capacity 5 buffer 에 envelope 7개를 enqueue") {
+            val buffer = TelemetryBuffer(props(5))
+            buffer.enqueueAll((1..7).map { env("$it") })
+
+            Then("size 는 capacity 인 5 로 제한됨 (drop oldest 발동)") {
+                buffer.size() shouldBe 5
+            }
+
+            When("drain(10)") {
+                val drained = buffer.drain(10)
+
+                Then("oldest 2개 (1,2) 가 폐기되고 마지막 5개 (3..7) 만 남아있음") {
+                    drained.map { it.sourceId } shouldBe listOf("3", "4", "5", "6", "7")
+                }
+            }
+        }
+
+        Given("buffer 재사용 시나리오 — enqueue → drain → enqueue") {
+            val buffer = TelemetryBuffer(props(10))
+            buffer.enqueueAll((1..3).map { env("$it") })
+            buffer.drain(10) // 첫 batch 비움
+            buffer.enqueueAll((4..6).map { env("$it") })
+
+            When("두 번째 drain") {
+                val drained = buffer.drain(10)
+
+                Then("두 번째 enqueue 한 것만 반환 — 첫 batch 와 섞이지 않음") {
+                    drained.map { it.sourceId } shouldBe listOf("4", "5", "6")
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarderTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarderTest.kt
@@ -1,0 +1,89 @@
+package com.pluxity.safersCollect.forwarder
+
+import com.pluxity.safersCollect.buffer.TelemetryBuffer
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.forwarder.enums.SourceType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class TelemetryForwarderTest :
+    BehaviorSpec({
+
+        fun props() =
+            SafersCollectProperties(
+                site = SafersCollectProperties.Site(id = 42L),
+                central = SafersCollectProperties.Central(ingestUrl = "http://test", apiKey = "test"),
+                buffer = SafersCollectProperties.Buffer(inMemoryMax = 1000),
+                forwarder =
+                    SafersCollectProperties.Forwarder(
+                        batchSize = 100,
+                        flushIntervalMs = 1000,
+                    ),
+            )
+
+        fun env(id: String) =
+            TelemetryEnvelope(
+                sourceType = SourceType.GAS,
+                sourceId = id,
+                timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                measurement = "gas_reading",
+            )
+
+        Given("buffer 가 비어있을 때") {
+            val buffer = mockk<TelemetryBuffer>(relaxed = true)
+            val client = mockk<CentralIngestClient>(relaxed = true)
+            every { buffer.drain(any()) } returns emptyList()
+
+            val forwarder = TelemetryForwarder(buffer, client, props())
+
+            When("flush 호출") {
+                forwarder.flush()
+
+                Then("client 호출 없이 즉시 반환") {
+                    verify(exactly = 0) { client.postTelemetry(any()) }
+                }
+            }
+        }
+
+        Given("buffer 에 envelope 3개 + central 정상") {
+            val buffer = mockk<TelemetryBuffer>(relaxed = true)
+            val client = mockk<CentralIngestClient>(relaxed = true)
+            val batch = listOf(env("1"), env("2"), env("3"))
+            every { buffer.drain(any()) } returns batch andThen emptyList()
+
+            val forwarder = TelemetryForwarder(buffer, client, props())
+
+            When("flush 호출") {
+                forwarder.flush()
+
+                Then("drain 한 batch 가 그대로 client 로 forward 됨") {
+                    verify(exactly = 1) { client.postTelemetry(batch) }
+                }
+                Then("재enqueue 발생 안 함 (정상 경로)") {
+                    verify(exactly = 0) { buffer.enqueueAll(any()) }
+                }
+            }
+        }
+
+        Given("client 가 예외를 던지는 상황") {
+            val buffer = mockk<TelemetryBuffer>(relaxed = true)
+            val client = mockk<CentralIngestClient>()
+            val batch = listOf(env("1"), env("2"))
+            every { buffer.drain(any()) } returns batch
+            every { client.postTelemetry(any()) } throws RuntimeException("central down")
+
+            val forwarder = TelemetryForwarder(buffer, client, props())
+
+            When("flush 호출") {
+                forwarder.flush()
+
+                Then("실패한 batch 를 buffer 로 재enqueue — 다음 주기에 자연 재시도") {
+                    verify(exactly = 1) { buffer.enqueueAll(batch) }
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/adapter/BandTelemetryAdapterTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/adapter/BandTelemetryAdapterTest.kt
@@ -1,0 +1,136 @@
+package com.pluxity.safersCollect.v1.collect.adapter
+
+import com.pluxity.safersCollect.v1.collect.dto.BandCollectRequest
+import com.pluxity.safersCollect.v1.collect.dto.BandSample
+import com.pluxity.safersCollect.v1.collect.dto.BandVitals
+import com.pluxity.safersCollect.v1.collect.dto.RawPosition
+import com.pluxity.safersCollect.v1.collect.enums.WearState
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class BandTelemetryAdapterTest :
+    BehaviorSpec({
+
+        val adapter = BandTelemetryAdapter()
+
+        Given("rawPosition / vitals / wearState / battery 모두 채워진 sample") {
+            val request =
+                BandCollectRequest(
+                    samples =
+                        listOf(
+                            BandSample(
+                                bandId = "BAND-A1B2C3",
+                                timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                                rawPosition =
+                                    RawPosition(
+                                        lat = 37.5665,
+                                        lng = 126.9780,
+                                        accuracyM = 3.5,
+                                    ),
+                                vitals =
+                                    BandVitals(
+                                        heartRateBpm = 70,
+                                        bodyTempC = 36.7,
+                                        spo2 = 97,
+                                        step = 4321,
+                                    ),
+                                battery = 100,
+                                wearState = WearState.WORN,
+                            ),
+                        ),
+                )
+
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("envelope 1개 — Band 는 fan-out 안 함") {
+                    envelopes.size shouldBe 1
+                }
+                Then("fields 에 lat/lng/accuracy_m/heart_rate_bpm/body_temp_c/spo2/step/battery 8개 모두") {
+                    envelopes.first().fields.keys shouldBe
+                        setOf(
+                            "lat",
+                            "lng",
+                            "accuracy_m",
+                            "heart_rate_bpm",
+                            "body_temp_c",
+                            "spo2",
+                            "step",
+                            "battery",
+                        )
+                }
+                Then("tag.wear_state 가 enum.name 으로 들어감") {
+                    envelopes.first().tags["wear_state"] shouldBe "WORN"
+                }
+            }
+        }
+
+        Given("rawPosition.accuracyM 만 null") {
+            val request =
+                BandCollectRequest(
+                    samples =
+                        listOf(
+                            BandSample(
+                                bandId = "BAND-A1B2C3",
+                                timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                                rawPosition =
+                                    RawPosition(
+                                        lat = 37.5665,
+                                        lng = 126.9780,
+                                        accuracyM = null,
+                                    ),
+                                vitals = null,
+                                battery = 100,
+                                wearState = WearState.WORN,
+                            ),
+                        ),
+                )
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("fields 에 lat/lng 은 있고 accuracy_m 는 없음") {
+                    envelopes.first().fields.keys shouldBe setOf("lat", "lng", "battery")
+                }
+            }
+        }
+
+        Given("samples 3건 (각각 다른 bandId)") {
+            val request =
+                BandCollectRequest(
+                    samples =
+                        listOf(
+                            BandSample(
+                                bandId = "BAND-01",
+                                timestamp = LocalDateTime.of(2026, 1, 1, 0, 0, 0),
+                                rawPosition = null,
+                                vitals = null,
+                                battery = null,
+                                wearState = null,
+                            ),
+                            BandSample(
+                                bandId = "BAND-02",
+                                timestamp = LocalDateTime.of(2026, 2, 1, 0, 0, 0),
+                                rawPosition = null,
+                                vitals = null,
+                                battery = null,
+                                wearState = null,
+                            ),
+                            BandSample(
+                                bandId = "BAND-03",
+                                timestamp = LocalDateTime.of(2026, 3, 1, 0, 0, 0),
+                                rawPosition = null,
+                                vitals = null,
+                                battery = null,
+                                wearState = null,
+                            ),
+                        ),
+                )
+
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("envelope 3개 — Gas 와 달리 fan-out 없이 1:1") {
+                    envelopes.size shouldBe 3
+                    envelopes.map { it.sourceId } shouldBe listOf("BAND-01", "BAND-02", "BAND-03")
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/adapter/GasTelemetryAdapterTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/adapter/GasTelemetryAdapterTest.kt
@@ -1,0 +1,193 @@
+package com.pluxity.safersCollect.v1.collect.adapter
+
+import com.pluxity.safersCollect.v1.collect.dto.GasCollectRequest
+import com.pluxity.safersCollect.v1.collect.dto.GasMeasurement
+import com.pluxity.safersCollect.v1.collect.dto.GasSample
+import com.pluxity.safersCollect.v1.collect.enums.GasType
+import com.pluxity.safersCollect.v1.collect.enums.GasUnit
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class GasTelemetryAdapterTest :
+    BehaviorSpec({
+
+        val adapter = GasTelemetryAdapter()
+
+        Given("한 sample 에 O2/H2S/CO/LEL 4개 측정값") {
+            val request =
+                GasCollectRequest(
+                    samples =
+                        listOf(
+                            GasSample(
+                                deviceId = "GAS-MH203-01",
+                                measurements =
+                                    listOf(
+                                        GasMeasurement(
+                                            gas = GasType.O2,
+                                            value = 3.1,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.H2S,
+                                            value = 1.2,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.CO,
+                                            value = 1.5,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.LEL,
+                                            value = 1.8,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                    ),
+                                battery = 100,
+                                signalRssi = -68,
+                                timestamp = LocalDateTime.now(),
+                            ),
+                        ),
+                )
+
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("envelope 4개 생성, 각각 measurement=gas_reading") {
+                    envelopes.size shouldBe 4
+                    envelopes.map { it.measurement } shouldBe listOf("gas_reading", "gas_reading", "gas_reading", "gas_reading")
+                }
+                Then("각 envelope 의 tag.gas / tag.unit 이 측정값과 일치") {
+                    envelopes.map { it.tags["gas"] } shouldBe listOf("O2", "H2S", "CO", "LEL")
+                    envelopes.map { it.tags["unit"] } shouldBe listOf("PPM", "PPM", "PPM", "PPM")
+                }
+            }
+        }
+
+        Given("battery 와 signalRssi 가 모두 null 인 sample") {
+
+            val request =
+                GasCollectRequest(
+                    samples =
+                        listOf(
+                            GasSample(
+                                deviceId = "GAS-MH203-01",
+                                measurements =
+                                    listOf(
+                                        GasMeasurement(
+                                            gas = GasType.O2,
+                                            value = 3.1,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                    ),
+                                battery = null,
+                                signalRssi = null,
+                                timestamp = LocalDateTime.now(),
+                            ),
+                        ),
+                )
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("fields 에 value 만 있고 battery / signal_rssi 키는 없음") {
+                    envelopes.map { it.fields.keys } shouldBe listOf(setOf("value"))
+                }
+            }
+        }
+
+        Given("타임스탬프 2026-04-24T10:15:30, deviceId GAS-MH203-01 sample") {
+            val timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30)
+
+            val request =
+                GasCollectRequest(
+                    samples =
+                        listOf(
+                            GasSample(
+                                deviceId = "GAS-MH203-01",
+                                measurements =
+                                    listOf(
+                                        GasMeasurement(
+                                            gas = GasType.O2,
+                                            value = 3.1,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.H2S,
+                                            value = 1.2,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                    ),
+                                battery = 100,
+                                signalRssi = -68,
+                                timestamp = timestamp,
+                            ),
+                        ),
+                )
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("모든 envelope 의 timestamp 와 sourceId 가 동일") {
+                    envelopes.forEach {
+                        it.timestamp shouldBe timestamp
+                        it.sourceId shouldBe "GAS-MH203-01"
+                    }
+                }
+            }
+        }
+
+        Given("samples 2건 (각 3 가스, 2 가스)") {
+            val request =
+                GasCollectRequest(
+                    samples =
+                        listOf(
+                            GasSample(
+                                deviceId = "GAS-MH203-01",
+                                measurements =
+                                    listOf(
+                                        GasMeasurement(
+                                            gas = GasType.O2,
+                                            value = 3.1,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.H2S,
+                                            value = 1.2,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.CO,
+                                            value = 1.5,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                    ),
+                                battery = 100,
+                                signalRssi = -68,
+                                timestamp = LocalDateTime.now(),
+                            ),
+                            GasSample(
+                                deviceId = "GAS-MH203-02",
+                                measurements =
+                                    listOf(
+                                        GasMeasurement(
+                                            gas = GasType.H2S,
+                                            value = 1.2,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                        GasMeasurement(
+                                            gas = GasType.CO,
+                                            value = 1.5,
+                                            unit = GasUnit.PPM,
+                                        ),
+                                    ),
+                                battery = 100,
+                                signalRssi = -68,
+                                timestamp = LocalDateTime.now(),
+                            ),
+                        ),
+                )
+            When("toEnvelopes 호출") {
+                val envelopes = adapter.toEnvelopes(request)
+                Then("envelope 총 5개 (3+2) 가 List 로 평탄화되어 반환") {
+                    envelopes.size shouldBe 5
+                }
+            }
+        }
+    })


### PR DESCRIPTION
 ## Summary
  - 가스/밴드 telemetry 수집 + 정규화 + 중앙 forward 파이프라인 구축
  - Adapter (raw → envelope) → Buffer  → Forwarder (`@Scheduled` batch)
  - safers-collect 가 처음부터 끝까지 동작 (디바이스 → InfluxDB)

  ## 변경
  - **adapter** (`v1/collect/adapter/`) — Gas/Band 정규화 envelope 변환
    - Gas: 1 sample × N 가스 → N envelope fan-out (스펙 §9.1.5)
    - Band: 1 sample = 1 envelope, nested nullable 처리
  - **buffer** (`buffer/TelemetryBuffer`) — `LinkedBlockingQueue(capacity)` + drop-oldest
  - **forwarder** (`forwarder/`) — `@Scheduled` 주기 batch 송신, 실패 시 재enqueue
  - **CentralIngestClient** — WebClient + X-Api-Key + path siteId

  ## 미구현 (후속 PR)
  - backoff (스펙 §11.2)
  - gzip (스펙 §11.2)
  - 디스크 spill (스펙 §11.2, §12.2)
  - 4xx vs 5xx 구분 (현재 모든 실패가 재enqueue → 무한 루프 위험)
  - WebClient timeout 명시
  - X-Api-Key 검증 (중앙 측 — 스펙 §13)

  ## Test plan
  - [x] adapter 단위 테스트 (Gas 4 케이스, Band 3 케이스)
  - [x] buffer 단위 테스트 (5 케이스 — drop oldest 포함)
  - [x] forwarder 단위 테스트 (3 케이스 — 빈 buffer / 정상 / 실패 재enqueue)
  - [x] E2E — safers + safers-collect + InfluxDB 띄우고 가스 데이터 한 줄 흘려보기