### PR TITLE
feat: ForwardQueue 백프레셔 (drop 메트릭)

### DIFF
--- a/apps/safers-collect/build.gradle.kts
+++ b/apps/safers-collect/build.gradle.kts
@@ -18,4 +18,5 @@ configurations.all {
 
 dependencies {
     implementation(rootProject.libs.spring.boot.starter.webflux)
+    implementation(rootProject.libs.spring.boot.starter.actuator)
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
@@ -1,12 +1,13 @@
 package com.pluxity.safersCollect.config
 
+import com.pluxity.safersCollect.queue.DropPolicy
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "safety-collector")
 data class SafersCollectProperties(
     val site: Site,
     val central: Central,
-    val buffer: Buffer,
+    val queue: Queue,
     val forwarder: Forwarder,
 ) {
     data class Site(
@@ -18,8 +19,9 @@ data class SafersCollectProperties(
         val apiKey: String,
     )
 
-    data class Buffer(
-        val inMemoryMax: Int,
+    data class Queue(
+        val normalCapacity: Int,
+        val dropPolicy: DropPolicy = DropPolicy.DROP_OLDEST,
     )
 
     data class Forwarder(

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarder.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarder.kt
@@ -1,7 +1,7 @@
 package com.pluxity.safersCollect.forwarder
 
-import com.pluxity.safersCollect.buffer.TelemetryBuffer
 import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.queue.ForwardQueue
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -10,20 +10,20 @@ private val log = KotlinLogging.logger {}
 
 @Component
 class TelemetryForwarder(
-    private val buffer: TelemetryBuffer,
+    private val queue: ForwardQueue,
     private val client: CentralIngestClient,
     private val props: SafersCollectProperties,
 ) {
     @Scheduled(fixedDelayString = "\${safety-collector.forwarder.flush-interval-ms}")
     fun flush() {
-        val batch = buffer.drain(props.forwarder.batchSize)
+        val batch = queue.drain(props.forwarder.batchSize)
         if (batch.isEmpty()) return
 
         try {
             client.postTelemetry(batch)
         } catch (e: Exception) {
             log.warn(e) { "telemetry forward 실패 — ${batch.size} envelope 재enqueue" }
-            buffer.enqueueAll(batch)
+            queue.enqueueAll(batch)
         }
     }
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicy.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicy.kt
@@ -1,0 +1,41 @@
+package com.pluxity.safersCollect.queue
+
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+import java.util.concurrent.BlockingQueue
+
+@Component
+class BackpressurePolicy(
+    props: SafersCollectProperties,
+    meterRegistry: MeterRegistry,
+) {
+    private val policy: DropPolicy = props.queue.dropPolicy
+    private val droppedCounter: Counter =
+        Counter
+            .builder(METRIC_QUEUE_DROPPED)
+            .description("ForwardQueue 가 가득 차서 폐기된 envelope 누적 수")
+            .tag("policy", policy.name)
+            .register(meterRegistry)
+
+    fun onOverflow(
+        queue: BlockingQueue<TelemetryEnvelope>,
+        item: TelemetryEnvelope,
+    ) {
+        when (policy) {
+            DropPolicy.DROP_OLDEST -> {
+                queue.poll()
+                droppedCounter.increment()
+                queue.offer(item)
+            }
+        }
+    }
+
+    fun droppedTotal(): Long = droppedCounter.count().toLong()
+
+    companion object {
+        const val METRIC_QUEUE_DROPPED = "collect.queue.dropped"
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicy.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicy.kt
@@ -26,9 +26,11 @@ class BackpressurePolicy(
     ) {
         when (policy) {
             DropPolicy.DROP_OLDEST -> {
-                queue.poll()
-                droppedCounter.increment()
-                queue.offer(item)
+                while (!queue.offer(item)) {
+                    if (queue.poll() != null) {
+                        droppedCounter.increment()
+                    }
+                }
             }
         }
     }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/DropPolicy.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/DropPolicy.kt
@@ -1,0 +1,5 @@
+package com.pluxity.safersCollect.queue
+
+enum class DropPolicy {
+    DROP_OLDEST,
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/ForwardQueue.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/queue/ForwardQueue.kt
@@ -1,4 +1,4 @@
-package com.pluxity.safersCollect.buffer
+package com.pluxity.safersCollect.queue
 
 import com.pluxity.safersCollect.config.SafersCollectProperties
 import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
@@ -7,14 +7,17 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 
 @Component
-class TelemetryBuffer(
-    prop: SafersCollectProperties,
+class ForwardQueue(
+    props: SafersCollectProperties,
+    private val backpressure: BackpressurePolicy,
 ) {
-    private val queue: BlockingQueue<TelemetryEnvelope> = LinkedBlockingQueue(prop.buffer.inMemoryMax)
+    private val queue: BlockingQueue<TelemetryEnvelope> = LinkedBlockingQueue(props.queue.normalCapacity)
 
     fun enqueueAll(items: Collection<TelemetryEnvelope>) {
-        items.forEach {
-            while (!queue.offer(it)) queue.poll()
+        items.forEach { item ->
+            if (!queue.offer(item)) {
+                backpressure.onOverflow(queue, item)
+            }
         }
     }
 

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/BandCollectController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/BandCollectController.kt
@@ -1,7 +1,7 @@
 package com.pluxity.safersCollect.v1.collect.controller
 
-import com.pluxity.safersCollect.buffer.TelemetryBuffer
 import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.queue.ForwardQueue
 import com.pluxity.safersCollect.v1.collect.adapter.BandEventAdapter
 import com.pluxity.safersCollect.v1.collect.adapter.BandTelemetryAdapter
 import com.pluxity.safersCollect.v1.collect.dto.BandCollectRequest
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 class BandCollectController(
     private val adapter: BandTelemetryAdapter,
     private val bandEventAdapter: BandEventAdapter,
-    private val buffer: TelemetryBuffer,
+    private val queue: ForwardQueue,
     private val eventForwarder: EventForwarder,
 ) {
     @Operation(summary = "스마트밴드 측정값 수집", description = "위치/체온/심박수/SpO2 등. 1~500건 batch.")
@@ -28,7 +28,7 @@ class BandCollectController(
     fun collect(
         @Valid @RequestBody request: BandCollectRequest,
     ) {
-        buffer.enqueueAll(adapter.toEnvelopes(request))
+        queue.enqueueAll(adapter.toEnvelopes(request))
     }
 
     @Operation(

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/GasCollectController.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/controller/GasCollectController.kt
@@ -1,7 +1,7 @@
 package com.pluxity.safersCollect.v1.collect.controller
 
-import com.pluxity.safersCollect.buffer.TelemetryBuffer
 import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.queue.ForwardQueue
 import com.pluxity.safersCollect.v1.collect.adapter.GasEventAdapter
 import com.pluxity.safersCollect.v1.collect.adapter.GasTelemetryAdapter
 import com.pluxity.safersCollect.v1.collect.dto.GasCollectRequest
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 class GasCollectController(
     private val gasAdapter: GasTelemetryAdapter,
     private val gasEventAdapter: GasEventAdapter,
-    private val buffer: TelemetryBuffer,
+    private val queue: ForwardQueue,
     private val eventForwarder: EventForwarder,
 ) {
     @Operation(summary = "유해가스 측정값 수집", description = "정상 범위 측정값 시계열 적재용. 1~500건 batch.")
@@ -28,7 +28,7 @@ class GasCollectController(
     fun collect(
         @Valid @RequestBody request: GasCollectRequest,
     ) {
-        buffer.enqueueAll(gasAdapter.toEnvelopes(request))
+        queue.enqueueAll(gasAdapter.toEnvelopes(request))
     }
 
     @Operation(summary = "유해가스 임계 초과 이벤트 수집", description = "임계 초과 시점에만 호출. 즉시 forward.")

--- a/apps/safers-collect/src/main/resources/application-common.yml
+++ b/apps/safers-collect/src/main/resources/application-common.yml
@@ -13,6 +13,18 @@ spring:
       max-file-size: 10GB
       max-request-size: 10GB
 
+management:
+  server:
+    port: ${MANAGEMENT_PORT:9091}
+    address: 127.0.0.1
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics
+  endpoint:
+    health:
+      show-details: always            # loopback only 라 안전
+
 springdoc:
   api-docs:
     path: /api-docs

--- a/apps/safers-collect/src/main/resources/application-local.yml
+++ b/apps/safers-collect/src/main/resources/application-local.yml
@@ -12,8 +12,9 @@ safety-collector:
   central:
     ingest-url: ${CENTRAL_INGEST_URL:http://localhost:8080}
     api-key: ${INGEST_API_KEY:pluxity}
-  buffer:
-    in-memory-max: 10000                            # 백프레셔 임계 (drop oldest)
+  queue:
+    normal-capacity: 10000                          # in-memory bounded queue capacity
+    drop-policy: DROP_OLDEST                        # 큐 가득 시 가장 오래된 envelope drop
   forwarder:
     batch-size: 100                                 # 한 번에 forward 할 envelope 수
     flush-interval-ms: 1000                         # @Scheduled fixedDelay (ms)

--- a/apps/safers-collect/src/main/resources/application-prod.yml
+++ b/apps/safers-collect/src/main/resources/application-prod.yml
@@ -12,8 +12,9 @@ safety-collector:
   central:
     ingest-url: ${CENTRAL_INGEST_URL}
     api-key: ${INGEST_API_KEY}
-  buffer:
-    in-memory-max: 10000
+  queue:
+    normal-capacity: ${QUEUE_NORMAL_CAPACITY:10000}
+    drop-policy: ${QUEUE_DROP_POLICY:DROP_OLDEST}
   forwarder:
-    batch-size: 100
-    flush-interval-ms: 1000
+    batch-size: ${FORWARDER_BATCH_SIZE:100}
+    flush-interval-ms: ${FORWARDER_FLUSH_INTERVAL_MS:1000}

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarderTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarderTest.kt
@@ -1,9 +1,10 @@
 package com.pluxity.safersCollect.forwarder
 
-import com.pluxity.safersCollect.buffer.TelemetryBuffer
 import com.pluxity.safersCollect.config.SafersCollectProperties
 import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
 import com.pluxity.safersCollect.forwarder.enums.SourceType
+import com.pluxity.safersCollect.queue.DropPolicy
+import com.pluxity.safersCollect.queue.ForwardQueue
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -17,7 +18,7 @@ class TelemetryForwarderTest :
             SafersCollectProperties(
                 site = SafersCollectProperties.Site(id = 42L),
                 central = SafersCollectProperties.Central(ingestUrl = "http://test", apiKey = "test"),
-                buffer = SafersCollectProperties.Buffer(inMemoryMax = 1000),
+                queue = SafersCollectProperties.Queue(normalCapacity = 1000, dropPolicy = DropPolicy.DROP_OLDEST),
                 forwarder =
                     SafersCollectProperties.Forwarder(
                         batchSize = 100,
@@ -33,12 +34,12 @@ class TelemetryForwarderTest :
                 measurement = "gas_reading",
             )
 
-        Given("buffer 가 비어있을 때") {
-            val buffer = mockk<TelemetryBuffer>(relaxed = true)
+        Given("queue 가 비어있을 때") {
+            val queue = mockk<ForwardQueue>(relaxed = true)
             val client = mockk<CentralIngestClient>(relaxed = true)
-            every { buffer.drain(any()) } returns emptyList()
+            every { queue.drain(any()) } returns emptyList()
 
-            val forwarder = TelemetryForwarder(buffer, client, props())
+            val forwarder = TelemetryForwarder(queue, client, props())
 
             When("flush 호출") {
                 forwarder.flush()
@@ -49,13 +50,13 @@ class TelemetryForwarderTest :
             }
         }
 
-        Given("buffer 에 envelope 3개 + central 정상") {
-            val buffer = mockk<TelemetryBuffer>(relaxed = true)
+        Given("queue 에 envelope 3개 + central 정상") {
+            val queue = mockk<ForwardQueue>(relaxed = true)
             val client = mockk<CentralIngestClient>(relaxed = true)
             val batch = listOf(env("1"), env("2"), env("3"))
-            every { buffer.drain(any()) } returns batch andThen emptyList()
+            every { queue.drain(any()) } returns batch andThen emptyList()
 
-            val forwarder = TelemetryForwarder(buffer, client, props())
+            val forwarder = TelemetryForwarder(queue, client, props())
 
             When("flush 호출") {
                 forwarder.flush()
@@ -64,25 +65,25 @@ class TelemetryForwarderTest :
                     verify(exactly = 1) { client.postTelemetry(batch) }
                 }
                 Then("재enqueue 발생 안 함 (정상 경로)") {
-                    verify(exactly = 0) { buffer.enqueueAll(any()) }
+                    verify(exactly = 0) { queue.enqueueAll(any()) }
                 }
             }
         }
 
         Given("client 가 예외를 던지는 상황") {
-            val buffer = mockk<TelemetryBuffer>(relaxed = true)
+            val queue = mockk<ForwardQueue>(relaxed = true)
             val client = mockk<CentralIngestClient>()
             val batch = listOf(env("1"), env("2"))
-            every { buffer.drain(any()) } returns batch
+            every { queue.drain(any()) } returns batch
             every { client.postTelemetry(any()) } throws RuntimeException("central down")
 
-            val forwarder = TelemetryForwarder(buffer, client, props())
+            val forwarder = TelemetryForwarder(queue, client, props())
 
             When("flush 호출") {
                 forwarder.flush()
 
-                Then("실패한 batch 를 buffer 로 재enqueue — 다음 주기에 자연 재시도") {
-                    verify(exactly = 1) { buffer.enqueueAll(batch) }
+                Then("실패한 batch 를 queue 로 재enqueue — 다음 주기에 자연 재시도") {
+                    verify(exactly = 1) { queue.enqueueAll(batch) }
                 }
             }
         }

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicyTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicyTest.kt
@@ -56,19 +56,19 @@ class BackpressurePolicyTest :
             }
         }
 
-        Given("DROP_OLDEST 정책 + 빈 큐 (overflow 가 아닌 비정상 호출)") {
+        Given("DROP_OLDEST 정책 + 빈 큐 (overflow 가 아닌 호출)") {
             val backpressure = BackpressurePolicy(props(DropPolicy.DROP_OLDEST), SimpleMeterRegistry())
             val queue = LinkedBlockingQueue<TelemetryEnvelope>(3)
 
             When("onOverflow 호출") {
                 backpressure.onOverflow(queue, env("X"))
 
-                Then("poll 은 null 반환하고 offer 는 성공 — 큐에 1개만 남음") {
+                Then("offer 가 즉시 성공 → poll 호출 없음 — 큐에 1개만 남음") {
                     queue.toList().map { it.sourceId } shouldBe listOf("X")
                 }
 
-                Then("dropped 카운터는 호출 자체로 1 증가 (비정상 호출도 drop 시도로 집계)") {
-                    backpressure.droppedTotal() shouldBe 1L
+                Then("dropped 카운터는 0 — 실제 drop 발생 안 함") {
+                    backpressure.droppedTotal() shouldBe 0L
                 }
             }
         }

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicyTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicyTest.kt
@@ -1,0 +1,97 @@
+package com.pluxity.safersCollect.queue
+
+import com.pluxity.safersCollect.config.SafersCollectProperties
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.forwarder.enums.SourceType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.time.LocalDateTime
+import java.util.concurrent.LinkedBlockingQueue
+
+class BackpressurePolicyTest :
+    BehaviorSpec({
+
+        fun props(policy: DropPolicy) =
+            SafersCollectProperties(
+                site = SafersCollectProperties.Site(id = 0L),
+                central = SafersCollectProperties.Central(ingestUrl = "http://test", apiKey = "test"),
+                queue = SafersCollectProperties.Queue(normalCapacity = 3, dropPolicy = policy),
+                forwarder =
+                    SafersCollectProperties.Forwarder(
+                        batchSize = 100,
+                        flushIntervalMs = 1000,
+                    ),
+            )
+
+        fun env(id: String) =
+            TelemetryEnvelope(
+                sourceType = SourceType.GAS,
+                sourceId = id,
+                timestamp = LocalDateTime.of(2026, 4, 24, 10, 15, 30),
+                measurement = "gas_reading",
+            )
+
+        Given("DROP_OLDEST 정책 + 가득 찬 큐") {
+            val backpressure = BackpressurePolicy(props(DropPolicy.DROP_OLDEST), SimpleMeterRegistry())
+            val queue = LinkedBlockingQueue<TelemetryEnvelope>(3)
+            queue.offer(env("1"))
+            queue.offer(env("2"))
+            queue.offer(env("3"))
+
+            When("onOverflow 로 새 envelope 추가") {
+                backpressure.onOverflow(queue, env("4"))
+
+                Then("oldest(1) 가 폐기되고 새 envelope 가 tail 에 들어감") {
+                    queue.toList().map { it.sourceId } shouldBe listOf("2", "3", "4")
+                }
+
+                Then("size 는 capacity 그대로 유지") {
+                    queue.size shouldBe 3
+                }
+
+                Then("dropped 카운터가 1 증가") {
+                    backpressure.droppedTotal() shouldBe 1L
+                }
+            }
+        }
+
+        Given("DROP_OLDEST 정책 + 빈 큐 (overflow 가 아닌 비정상 호출)") {
+            val backpressure = BackpressurePolicy(props(DropPolicy.DROP_OLDEST), SimpleMeterRegistry())
+            val queue = LinkedBlockingQueue<TelemetryEnvelope>(3)
+
+            When("onOverflow 호출") {
+                backpressure.onOverflow(queue, env("X"))
+
+                Then("poll 은 null 반환하고 offer 는 성공 — 큐에 1개만 남음") {
+                    queue.toList().map { it.sourceId } shouldBe listOf("X")
+                }
+
+                Then("dropped 카운터는 호출 자체로 1 증가 (비정상 호출도 drop 시도로 집계)") {
+                    backpressure.droppedTotal() shouldBe 1L
+                }
+            }
+        }
+
+        Given("연속 overflow 시나리오 — 큐 가득 + onOverflow 5회 호출") {
+            val backpressure = BackpressurePolicy(props(DropPolicy.DROP_OLDEST), SimpleMeterRegistry())
+            val queue = LinkedBlockingQueue<TelemetryEnvelope>(3)
+            queue.offer(env("a"))
+            queue.offer(env("b"))
+            queue.offer(env("c"))
+
+            When("onOverflow(d), onOverflow(e), onOverflow(f), onOverflow(g), onOverflow(h)") {
+                listOf("d", "e", "f", "g", "h").forEach {
+                    backpressure.onOverflow(queue, env(it))
+                }
+
+                Then("dropped 카운터가 5 누적") {
+                    backpressure.droppedTotal() shouldBe 5L
+                }
+
+                Then("최신 3개만 큐에 남음") {
+                    queue.toList().map { it.sourceId } shouldBe listOf("f", "g", "h")
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/ForwardQueueTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/ForwardQueueTest.kt
@@ -1,4 +1,4 @@
-package com.pluxity.safersCollect.buffer
+package com.pluxity.safersCollect.queue
 
 import com.pluxity.safersCollect.config.SafersCollectProperties
 import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
@@ -6,22 +6,28 @@ import com.pluxity.safersCollect.forwarder.enums.SourceType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import java.time.LocalDateTime
 
-class TelemetryBufferTest :
+class ForwardQueueTest :
     BehaviorSpec({
 
         fun props(capacity: Int) =
             SafersCollectProperties(
                 site = SafersCollectProperties.Site(id = 0L),
                 central = SafersCollectProperties.Central(ingestUrl = "http://test", apiKey = "test"),
-                buffer = SafersCollectProperties.Buffer(inMemoryMax = capacity),
+                queue = SafersCollectProperties.Queue(normalCapacity = capacity, dropPolicy = DropPolicy.DROP_OLDEST),
                 forwarder =
                     SafersCollectProperties.Forwarder(
                         batchSize = 100,
                         flushIntervalMs = 1000,
                     ),
             )
+
+        fun queueOf(capacity: Int): ForwardQueue {
+            val p = props(capacity)
+            return ForwardQueue(p, BackpressurePolicy(p, SimpleMeterRegistry()))
+        }
 
         fun env(id: String) =
             TelemetryEnvelope(
@@ -31,15 +37,15 @@ class TelemetryBufferTest :
                 measurement = "gas_reading",
             )
 
-        Given("빈 buffer") {
-            val buffer = TelemetryBuffer(props(10))
+        Given("빈 queue") {
+            val queue = queueOf(10)
 
             Then("size 는 0") {
-                buffer.size() shouldBe 0
+                queue.size() shouldBe 0
             }
 
             When("drain(5) 호출") {
-                val drained = buffer.drain(5)
+                val drained = queue.drain(5)
 
                 Then("emptyList 반환 — block 안 함") {
                     drained shouldBe emptyList()
@@ -47,49 +53,49 @@ class TelemetryBufferTest :
             }
         }
 
-        Given("envelope 5개를 enqueue 한 buffer (capacity 10)") {
-            val buffer = TelemetryBuffer(props(10))
-            buffer.enqueueAll((1..5).map { env("$it") })
+        Given("envelope 5개를 enqueue 한 queue (capacity 10)") {
+            val queue = queueOf(10)
+            queue.enqueueAll((1..5).map { env("$it") })
 
             Then("size 는 5") {
-                buffer.size() shouldBe 5
+                queue.size() shouldBe 5
             }
 
             When("drain(3) — drain less than size") {
-                val drained = buffer.drain(3)
+                val drained = queue.drain(3)
 
                 Then("oldest 3개를 순서대로 반환 + size 는 2 로 줄어듦") {
                     drained.map { it.sourceId } shouldBe listOf("1", "2", "3")
-                    buffer.size() shouldBe 2
+                    queue.size() shouldBe 2
                 }
             }
         }
 
-        Given("envelope 3개를 enqueue 한 buffer (capacity 10)") {
-            val buffer = TelemetryBuffer(props(10))
-            buffer.enqueueAll((1..3).map { env("$it") })
+        Given("envelope 3개를 enqueue 한 queue (capacity 10)") {
+            val queue = queueOf(10)
+            queue.enqueueAll((1..3).map { env("$it") })
 
             When("drain(10) — drain more than size") {
-                val drained = buffer.drain(10)
+                val drained = queue.drain(10)
 
                 Then("있는 3개 전부 반환 + size 0 — block 없이 즉시") {
                     drained shouldHaveSize 3
                     drained.map { it.sourceId } shouldBe listOf("1", "2", "3")
-                    buffer.size() shouldBe 0
+                    queue.size() shouldBe 0
                 }
             }
         }
 
-        Given("capacity 5 buffer 에 envelope 7개를 enqueue") {
-            val buffer = TelemetryBuffer(props(5))
-            buffer.enqueueAll((1..7).map { env("$it") })
+        Given("capacity 5 queue 에 envelope 7개를 enqueue (overflow)") {
+            val queue = queueOf(5)
+            queue.enqueueAll((1..7).map { env("$it") })
 
-            Then("size 는 capacity 인 5 로 제한됨 (drop oldest 발동)") {
-                buffer.size() shouldBe 5
+            Then("size 는 capacity 인 5 로 제한됨 (drop-oldest 정책 적용)") {
+                queue.size() shouldBe 5
             }
 
             When("drain(10)") {
-                val drained = buffer.drain(10)
+                val drained = queue.drain(10)
 
                 Then("oldest 2개 (1,2) 가 폐기되고 마지막 5개 (3..7) 만 남아있음") {
                     drained.map { it.sourceId } shouldBe listOf("3", "4", "5", "6", "7")
@@ -97,14 +103,14 @@ class TelemetryBufferTest :
             }
         }
 
-        Given("buffer 재사용 시나리오 — enqueue → drain → enqueue") {
-            val buffer = TelemetryBuffer(props(10))
-            buffer.enqueueAll((1..3).map { env("$it") })
-            buffer.drain(10) // 첫 batch 비움
-            buffer.enqueueAll((4..6).map { env("$it") })
+        Given("queue 재사용 시나리오 — enqueue → drain → enqueue") {
+            val queue = queueOf(10)
+            queue.enqueueAll((1..3).map { env("$it") })
+            queue.drain(10) // 첫 batch 비움
+            queue.enqueueAll((4..6).map { env("$it") })
 
             When("두 번째 drain") {
-                val drained = buffer.drain(10)
+                val drained = queue.drain(10)
 
                 Then("두 번째 enqueue 한 것만 반환 — 첫 batch 와 섞이지 않음") {
                     drained.map { it.sourceId } shouldBe listOf("4", "5", "6")


### PR DESCRIPTION
- buffer 패키지를 queue 로 리네임 + 변수명 통일
- DROP_OLDEST 정책을 BackpressurePolicy 로 분리
- collect.queue.dropped 노출
- actuator 를 loopback only 별도 포트로 분리 → 외부 차단
