### PR TITLE
feat(safers-collect): MQTT 인그레스 + Springwolf AsyncAPI 문서화

### DIFF
--- a/apps/safers-collect/build.gradle.kts
+++ b/apps/safers-collect/build.gradle.kts
@@ -19,4 +19,5 @@ configurations.all {
 dependencies {
     implementation(rootProject.libs.spring.boot.starter.webflux)
     implementation(rootProject.libs.spring.boot.starter.actuator)
+    implementation(rootProject.libs.hivemq.mqtt.client)
 }

--- a/apps/safers-collect/build.gradle.kts
+++ b/apps/safers-collect/build.gradle.kts
@@ -20,4 +20,7 @@ dependencies {
     implementation(rootProject.libs.spring.boot.starter.webflux)
     implementation(rootProject.libs.spring.boot.starter.actuator)
     implementation(rootProject.libs.hivemq.mqtt.client)
+    implementation(rootProject.libs.springwolf.core)
+    implementation(rootProject.libs.springwolf.generic.binding)
+    runtimeOnly(rootProject.libs.springwolf.ui)
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -10,14 +10,12 @@ import org.springframework.context.annotation.Configuration
 @ConditionalOnExpression($$"'${safety-collector.mqtt.host:}' != ''")
 class MqttClientConfig {
     @Bean
-    fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient {
-        val mqtt = props.mqtt!!
-        return Mqtt5Client
+    fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient =
+        Mqtt5Client
             .builder()
-            .identifier(mqtt.clientId)
-            .serverHost(mqtt.host)
-            .serverPort(mqtt.port)
+            .identifier(props.mqtt.clientId)
+            .serverHost(props.mqtt.host)
+            .serverPort(props.mqtt.port)
             .automaticReconnectWithDefaultConfig()
             .buildAsync()
-    }
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration
 class MqttClientConfig {
     @Bean
     fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient {
-        val mqtt = checkNotNull(props.mqtt) { "safety-collector.mqtt 설정이 필요합니다." }
+        val mqtt = props.mqtt!!
         return Mqtt5Client
             .builder()
             .identifier(mqtt.clientId)

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -2,18 +2,22 @@ package com.pluxity.safersCollect.config
 
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
+@ConditionalOnExpression("'\${safety-collector.mqtt.host:}' != ''")
 class MqttClientConfig {
     @Bean
-    fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient =
-        Mqtt5Client
+    fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient {
+        val mqtt = checkNotNull(props.mqtt) { "safety-collector.mqtt 설정이 필요합니다." }
+        return Mqtt5Client
             .builder()
-            .identifier(props.mqtt.clientId)
-            .serverHost(props.mqtt.host)
-            .serverPort(props.mqtt.port)
+            .identifier(mqtt.clientId)
+            .serverHost(mqtt.host)
+            .serverPort(mqtt.port)
             .automaticReconnectWithDefaultConfig()
             .buildAsync()
+    }
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -1,5 +1,6 @@
 package com.pluxity.safersCollect.config
 
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter
 import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client
@@ -20,6 +21,9 @@ class MqttClientConfig {
         props: SafersCollectProperties,
         handlers: List<MqttIngressHandler>,
     ): Mqtt5AsyncClient {
+        val handlersByTopic =
+            handlers.associateBy { "${props.mqtt.topicPrefix}/${it.topicSuffix}" }
+
         lateinit var client: Mqtt5AsyncClient
         client =
             Mqtt5Client
@@ -30,19 +34,12 @@ class MqttClientConfig {
                 .automaticReconnectWithDefaultConfig()
                 .addConnectedListener {
                     log.info { "MQTT connected to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
-                    handlers.forEach { handler ->
-                        val topic = "${props.mqtt.topicPrefix}/${handler.topicSuffix}"
+                    handlersByTopic.keys.forEach { topic ->
                         client
                             .subscribeWith()
                             .topicFilter(topic)
                             .qos(MqttQos.AT_LEAST_ONCE)
-                            .callback { publish ->
-                                try {
-                                    handler.handle(publish.payloadAsBytes)
-                                } catch (ex: Exception) {
-                                    log.error(ex) { "MQTT handler failed for topic=$topic" }
-                                }
-                            }.send()
+                            .send()
                             .whenComplete { _: Mqtt5SubAck?, ex: Throwable? ->
                                 if (ex == null) {
                                     log.info { "MQTT subscribed: $topic (QoS 1)" }
@@ -52,6 +49,21 @@ class MqttClientConfig {
                             }
                     }
                 }.buildAsync()
+
+        client.publishes(MqttGlobalPublishFilter.SUBSCRIBED) { publish ->
+            val topic = publish.topic.toString()
+            val handler = handlersByTopic[topic]
+            if (handler == null) {
+                log.warn { "No handler registered for topic=$topic" }
+                return@publishes
+            }
+            try {
+                handler.handle(publish.payloadAsBytes)
+            } catch (ex: Exception) {
+                log.error(ex) { "MQTT handler failed for topic=$topic" }
+            }
+        }
+
         return client
     }
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnExpression("'\${safety-collector.mqtt.host:}' != ''")
+@ConditionalOnExpression($$"'${safety-collector.mqtt.host:}' != ''")
 class MqttClientConfig {
     @Bean
     fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient {

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -1,0 +1,19 @@
+package com.pluxity.safersCollect.config
+
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
+import com.hivemq.client.mqtt.mqtt5.Mqtt5Client
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MqttClientConfig {
+    @Bean
+    fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient =
+        Mqtt5Client
+            .builder()
+            .identifier(props.mqtt.clientId)
+            .serverHost(props.mqtt.host)
+            .serverPort(props.mqtt.port)
+            .automaticReconnectWithDefaultConfig()
+            .buildAsync()
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttClientConfig.kt
@@ -1,21 +1,57 @@
 package com.pluxity.safersCollect.config
 
+import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client
+import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck
+import com.pluxity.safersCollect.v1.collect.mqtt.MqttIngressHandler
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+
+private val log = KotlinLogging.logger {}
 
 @Configuration
 @ConditionalOnExpression($$"'${safety-collector.mqtt.host:}' != ''")
 class MqttClientConfig {
     @Bean
-    fun mqtt5AsyncClient(props: SafersCollectProperties): Mqtt5AsyncClient =
-        Mqtt5Client
-            .builder()
-            .identifier(props.mqtt.clientId)
-            .serverHost(props.mqtt.host)
-            .serverPort(props.mqtt.port)
-            .automaticReconnectWithDefaultConfig()
-            .buildAsync()
+    fun mqtt5AsyncClient(
+        props: SafersCollectProperties,
+        handlers: List<MqttIngressHandler>,
+    ): Mqtt5AsyncClient {
+        lateinit var client: Mqtt5AsyncClient
+        client =
+            Mqtt5Client
+                .builder()
+                .identifier(props.mqtt.clientId)
+                .serverHost(props.mqtt.host)
+                .serverPort(props.mqtt.port)
+                .automaticReconnectWithDefaultConfig()
+                .addConnectedListener {
+                    log.info { "MQTT connected to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
+                    handlers.forEach { handler ->
+                        val topic = "${props.mqtt.topicPrefix}/${handler.topicSuffix}"
+                        client
+                            .subscribeWith()
+                            .topicFilter(topic)
+                            .qos(MqttQos.AT_LEAST_ONCE)
+                            .callback { publish ->
+                                try {
+                                    handler.handle(publish.payloadAsBytes)
+                                } catch (ex: Exception) {
+                                    log.error(ex) { "MQTT handler failed for topic=$topic" }
+                                }
+                            }.send()
+                            .whenComplete { _: Mqtt5SubAck?, ex: Throwable? ->
+                                if (ex == null) {
+                                    log.info { "MQTT subscribed: $topic (QoS 1)" }
+                                } else {
+                                    log.error(ex) { "MQTT subscribe failed: $topic" }
+                                }
+                            }
+                    }
+                }.buildAsync()
+        return client
+    }
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -24,7 +24,7 @@ class MqttSubscriberStarter(
 ) {
     @EventListener(ApplicationReadyEvent::class)
     fun start() {
-        val mqtt = checkNotNull(props.mqtt) { "safety-collector.mqtt 설정이 필요합니다." }
+        val mqtt = props.mqtt!!
         client
             .connect()
             .thenCompose {

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -6,6 +6,7 @@ import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck
 import com.pluxity.safersCollect.v1.collect.mqtt.MqttIngressHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PreDestroy
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -15,6 +16,7 @@ import java.util.concurrent.TimeUnit
 private val log = KotlinLogging.logger {}
 
 @Component
+@ConditionalOnExpression("'\${safety-collector.mqtt.host:}' != ''")
 class MqttSubscriberStarter(
     private val client: Mqtt5AsyncClient,
     private val handlers: List<MqttIngressHandler>,
@@ -22,13 +24,14 @@ class MqttSubscriberStarter(
 ) {
     @EventListener(ApplicationReadyEvent::class)
     fun start() {
+        val mqtt = checkNotNull(props.mqtt) { "safety-collector.mqtt 설정이 필요합니다." }
         client
             .connect()
             .thenCompose {
-                log.info { "MQTT connected to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
+                log.info { "MQTT connected to ${mqtt.host}:${mqtt.port} as ${mqtt.clientId}" }
                 val subs =
                     handlers.map { handler ->
-                        val topic = "${props.mqtt.topicPrefix}/${handler.topicSuffix}"
+                        val topic = "${mqtt.topicPrefix}/${handler.topicSuffix}"
                         client
                             .subscribeWith()
                             .topicFilter(topic)

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -1,16 +1,12 @@
 package com.pluxity.safersCollect.config
 
-import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
-import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck
-import com.pluxity.safersCollect.v1.collect.mqtt.MqttIngressHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PreDestroy
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 private val log = KotlinLogging.logger {}
@@ -19,42 +15,15 @@ private val log = KotlinLogging.logger {}
 @ConditionalOnExpression($$"'${safety-collector.mqtt.host:}' != ''")
 class MqttSubscriberStarter(
     private val client: Mqtt5AsyncClient,
-    private val handlers: List<MqttIngressHandler>,
     private val props: SafersCollectProperties,
 ) {
     @EventListener(ApplicationReadyEvent::class)
     fun start() {
-        client
-            .connect()
-            .thenCompose {
-                log.info { "MQTT connected to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
-                val subs =
-                    handlers.map { handler ->
-                        val topic = "${props.mqtt.topicPrefix}/${handler.topicSuffix}"
-                        client
-                            .subscribeWith()
-                            .topicFilter(topic)
-                            .qos(MqttQos.AT_LEAST_ONCE)
-                            .callback { publish ->
-                                try {
-                                    handler.handle(publish.payloadAsBytes)
-                                } catch (ex: Exception) {
-                                    log.error(ex) { "MQTT handler failed for topic=$topic" }
-                                }
-                            }.send()
-                            .whenComplete { _: Mqtt5SubAck?, ex: Throwable? ->
-                                if (ex == null) {
-                                    log.info { "MQTT subscribed: $topic (QoS 1)" }
-                                } else {
-                                    log.error(ex) { "MQTT subscribe failed: $topic" }
-                                }
-                            }
-                    }
-                CompletableFuture.allOf(*subs.toTypedArray())
-            }.exceptionally { ex ->
-                log.error(ex) { "MQTT startup failed" }
-                null
-            }
+        log.info { "MQTT connecting to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
+        client.connect().exceptionally { ex ->
+            log.error(ex) { "MQTT initial connect failed — automatic reconnect 가 백그라운드에서 재시도합니다" }
+            null
+        }
     }
 
     @PreDestroy

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -1,0 +1,66 @@
+package com.pluxity.safersCollect.config
+
+import com.hivemq.client.mqtt.datatypes.MqttQos
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
+import com.pluxity.safersCollect.v1.collect.mqtt.MqttIngressHandler
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.annotation.PreDestroy
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class MqttSubscriberStarter(
+    private val client: Mqtt5AsyncClient,
+    private val handlers: List<MqttIngressHandler>,
+    private val props: SafersCollectProperties,
+) {
+    @EventListener(ApplicationReadyEvent::class)
+    fun start() {
+        client
+            .connect()
+            .thenCompose {
+                log.info { "MQTT connected to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
+                val subs =
+                    handlers.map { handler ->
+                        val topic = "${props.mqtt.topicPrefix}/${handler.topicSuffix}"
+                        client
+                            .subscribeWith()
+                            .topicFilter(topic)
+                            .qos(MqttQos.AT_LEAST_ONCE)
+                            .callback { publish ->
+                                try {
+                                    handler.handle(publish.payloadAsBytes)
+                                } catch (ex: Exception) {
+                                    log.error(ex) { "MQTT handler failed for topic=$topic" }
+                                }
+                            }.send()
+                            .whenComplete { _, ex ->
+                                if (ex == null) {
+                                    log.info { "MQTT subscribed: $topic (QoS 1)" }
+                                } else {
+                                    log.error(ex) { "MQTT subscribe failed: $topic" }
+                                }
+                            }
+                    }
+                CompletableFuture.allOf(*subs.toTypedArray())
+            }.exceptionally { ex ->
+                log.error(ex) { "MQTT startup failed" }
+                null
+            }
+    }
+
+    @PreDestroy
+    fun stop() {
+        try {
+            client.disconnect().get(5, TimeUnit.SECONDS)
+            log.info { "MQTT disconnected" }
+        } catch (ex: Exception) {
+            log.warn(ex) { "MQTT disconnect did not complete cleanly" }
+        }
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit
 private val log = KotlinLogging.logger {}
 
 @Component
-@ConditionalOnExpression("'\${safety-collector.mqtt.host:}' != ''")
+@ConditionalOnExpression($$"'${safety-collector.mqtt.host:}' != ''")
 class MqttSubscriberStarter(
     private val client: Mqtt5AsyncClient,
     private val handlers: List<MqttIngressHandler>,

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -2,6 +2,7 @@ package com.pluxity.safersCollect.config
 
 import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient
+import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck
 import com.pluxity.safersCollect.v1.collect.mqtt.MqttIngressHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PreDestroy
@@ -39,7 +40,7 @@ class MqttSubscriberStarter(
                                     log.error(ex) { "MQTT handler failed for topic=$topic" }
                                 }
                             }.send()
-                            .whenComplete { _, ex ->
+                            .whenComplete { _: Mqtt5SubAck?, ex: Throwable? ->
                                 if (ex == null) {
                                     log.info { "MQTT subscribed: $topic (QoS 1)" }
                                 } else {

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/MqttSubscriberStarter.kt
@@ -24,14 +24,13 @@ class MqttSubscriberStarter(
 ) {
     @EventListener(ApplicationReadyEvent::class)
     fun start() {
-        val mqtt = props.mqtt!!
         client
             .connect()
             .thenCompose {
-                log.info { "MQTT connected to ${mqtt.host}:${mqtt.port} as ${mqtt.clientId}" }
+                log.info { "MQTT connected to ${props.mqtt.host}:${props.mqtt.port} as ${props.mqtt.clientId}" }
                 val subs =
                     handlers.map { handler ->
-                        val topic = "${mqtt.topicPrefix}/${handler.topicSuffix}"
+                        val topic = "${props.mqtt.topicPrefix}/${handler.topicSuffix}"
                         client
                             .subscribeWith()
                             .topicFilter(topic)

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
@@ -9,7 +9,7 @@ data class SafersCollectProperties(
     val central: Central,
     val queue: Queue,
     val forwarder: Forwarder,
-    val mqtt: Mqtt? = null,
+    val mqtt: Mqtt = Mqtt(),
 ) {
     data class Site(
         val id: Long,
@@ -31,9 +31,9 @@ data class SafersCollectProperties(
     )
 
     data class Mqtt(
-        val host: String,
-        val port: Int,
-        val clientId: String,
-        val topicPrefix: String,
+        val host: String = "",
+        val port: Int = 1883,
+        val clientId: String = "safers-collect",
+        val topicPrefix: String = "safers/collect",
     )
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
@@ -9,6 +9,7 @@ data class SafersCollectProperties(
     val central: Central,
     val queue: Queue,
     val forwarder: Forwarder,
+    val mqtt: Mqtt,
 ) {
     data class Site(
         val id: Long,
@@ -27,5 +28,12 @@ data class SafersCollectProperties(
     data class Forwarder(
         val batchSize: Int,
         val flushIntervalMs: Long,
+    )
+
+    data class Mqtt(
+        val host: String,
+        val port: Int,
+        val clientId: String,
+        val topicPrefix: String,
     )
 }

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/config/SafersCollectProperties.kt
@@ -9,7 +9,7 @@ data class SafersCollectProperties(
     val central: Central,
     val queue: Queue,
     val forwarder: Forwarder,
-    val mqtt: Mqtt,
+    val mqtt: Mqtt? = null,
 ) {
     data class Site(
         val id: Long,

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandEventMqttHandler.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandEventMqttHandler.kt
@@ -1,0 +1,36 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.v1.collect.adapter.BandEventAdapter
+import com.pluxity.safersCollect.v1.collect.dto.BandEventRequest
+import io.github.springwolf.addons.generic_binding.annotation.AsyncGenericOperationBinding
+import io.github.springwolf.core.asyncapi.annotations.AsyncListener
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class BandEventMqttHandler(
+    private val objectMapper: ObjectMapper,
+    private val adapter: BandEventAdapter,
+    private val eventForwarder: EventForwarder,
+) : MqttIngressHandler {
+    override val topicSuffix: String = "band/events"
+
+    @AsyncListener(
+        operation =
+            AsyncOperation(
+                channelName = "safers/collect/band/events",
+                description = "스마트밴드 이상 이벤트 (VITAL_ABNORMAL / FALL_DETECTED / OFFLINE). eventType 으로 구분. publisher = 스마트밴드.",
+                payloadType = BandEventRequest::class,
+            ),
+    )
+    @AsyncGenericOperationBinding(
+        type = "mqtt",
+        fields = ["qos=1", "retain=false"],
+    )
+    override fun handle(payload: ByteArray) {
+        val request = objectMapper.readValue(payload, BandEventRequest::class.java)
+        eventForwarder.forward(adapter.toEnvelope(request))
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandTelemetryMqttHandler.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandTelemetryMqttHandler.kt
@@ -1,0 +1,36 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.queue.ForwardQueue
+import com.pluxity.safersCollect.v1.collect.adapter.BandTelemetryAdapter
+import com.pluxity.safersCollect.v1.collect.dto.BandTelemetry
+import io.github.springwolf.addons.generic_binding.annotation.AsyncGenericOperationBinding
+import io.github.springwolf.core.asyncapi.annotations.AsyncListener
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class BandTelemetryMqttHandler(
+    private val objectMapper: ObjectMapper,
+    private val adapter: BandTelemetryAdapter,
+    private val queue: ForwardQueue,
+) : MqttIngressHandler {
+    override val topicSuffix: String = "band/telemetry"
+
+    @AsyncListener(
+        operation =
+            AsyncOperation(
+                channelName = "safers/collect/band/telemetry",
+                description = "스마트밴드 단건 측정값. publisher = 스마트밴드.",
+                payloadType = BandTelemetry::class,
+            ),
+    )
+    @AsyncGenericOperationBinding(
+        type = "mqtt",
+        fields = ["qos=1", "retain=false"],
+    )
+    override fun handle(payload: ByteArray) {
+        val request = objectMapper.readValue(payload, BandTelemetry::class.java)
+        queue.enqueueAll(adapter.toEnvelopes(request))
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasEventMqttHandler.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasEventMqttHandler.kt
@@ -1,0 +1,36 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.v1.collect.adapter.GasEventAdapter
+import com.pluxity.safersCollect.v1.collect.dto.GasEventRequest
+import io.github.springwolf.addons.generic_binding.annotation.AsyncGenericOperationBinding
+import io.github.springwolf.core.asyncapi.annotations.AsyncListener
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class GasEventMqttHandler(
+    private val objectMapper: ObjectMapper,
+    private val adapter: GasEventAdapter,
+    private val eventForwarder: EventForwarder,
+) : MqttIngressHandler {
+    override val topicSuffix: String = "gas/events"
+
+    @AsyncListener(
+        operation =
+            AsyncOperation(
+                channelName = "safers/collect/gas/events",
+                description = "가스 임계 초과 이벤트. publisher = 가스 센서 디바이스. 임계 초과 시점에만 발행.",
+                payloadType = GasEventRequest::class,
+            ),
+    )
+    @AsyncGenericOperationBinding(
+        type = "mqtt",
+        fields = ["qos=1", "retain=false"],
+    )
+    override fun handle(payload: ByteArray) {
+        val request = objectMapper.readValue(payload, GasEventRequest::class.java)
+        eventForwarder.forward(adapter.toEnvelope(request))
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasTelemetryMqttHandler.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasTelemetryMqttHandler.kt
@@ -1,0 +1,36 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.queue.ForwardQueue
+import com.pluxity.safersCollect.v1.collect.adapter.GasTelemetryAdapter
+import com.pluxity.safersCollect.v1.collect.dto.GasTelemetry
+import io.github.springwolf.addons.generic_binding.annotation.AsyncGenericOperationBinding
+import io.github.springwolf.core.asyncapi.annotations.AsyncListener
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class GasTelemetryMqttHandler(
+    private val objectMapper: ObjectMapper,
+    private val adapter: GasTelemetryAdapter,
+    private val queue: ForwardQueue,
+) : MqttIngressHandler {
+    override val topicSuffix: String = "gas/telemetry"
+
+    @AsyncListener(
+        operation =
+            AsyncOperation(
+                channelName = "safers/collect/gas/telemetry",
+                description = "가스 센서 단건 측정값. publisher = 가스 센서 디바이스.",
+                payloadType = GasTelemetry::class,
+            ),
+    )
+    @AsyncGenericOperationBinding(
+        type = "mqtt",
+        fields = ["qos=1", "retain=false"],
+    )
+    override fun handle(payload: ByteArray) {
+        val request = objectMapper.readValue(payload, GasTelemetry::class.java)
+        queue.enqueueAll(adapter.toEnvelopes(request))
+    }
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/MqttIngressHandler.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/MqttIngressHandler.kt
@@ -1,0 +1,7 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+interface MqttIngressHandler {
+    val topicSuffix: String
+
+    fun handle(payload: ByteArray)
+}

--- a/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/SosEventMqttHandler.kt
+++ b/apps/safers-collect/src/main/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/SosEventMqttHandler.kt
@@ -1,0 +1,36 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.v1.collect.adapter.SosEventAdapter
+import com.pluxity.safersCollect.v1.collect.dto.SosEventRequest
+import io.github.springwolf.addons.generic_binding.annotation.AsyncGenericOperationBinding
+import io.github.springwolf.core.asyncapi.annotations.AsyncListener
+import io.github.springwolf.core.asyncapi.annotations.AsyncOperation
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class SosEventMqttHandler(
+    private val objectMapper: ObjectMapper,
+    private val adapter: SosEventAdapter,
+    private val eventForwarder: EventForwarder,
+) : MqttIngressHandler {
+    override val topicSuffix: String = "sos/events"
+
+    @AsyncListener(
+        operation =
+            AsyncOperation(
+                channelName = "safers/collect/sos/events",
+                description = "SOS 긴급호출 이벤트 (BUTTON_LONG_PRESS / MOBILE_APP / MANUAL_DISPATCH). publisher = 스마트밴드 / 모바일 앱 / 관제센터.",
+                payloadType = SosEventRequest::class,
+            ),
+    )
+    @AsyncGenericOperationBinding(
+        type = "mqtt",
+        fields = ["qos=1", "retain=false"],
+    )
+    override fun handle(payload: ByteArray) {
+        val request = objectMapper.readValue(payload, SosEventRequest::class.java)
+        eventForwarder.forward(adapter.toEnvelope(request))
+    }
+}

--- a/apps/safers-collect/src/main/resources/application-common.yml
+++ b/apps/safers-collect/src/main/resources/application-common.yml
@@ -35,3 +35,25 @@ springdoc:
   packages-to-scan: com.pluxity
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+springwolf:
+  enabled: true
+  docket:
+    default-content-type: application/json
+    base-package: com.pluxity.safersCollect.v1.collect.mqtt
+    info:
+      title: Safers Collect MQTT Ingress
+      version: 1.0.0
+      description: |
+        센서 및 디바이스가 MQTT 브로커에 발행해야 하는 메시지 contract.
+
+        ## 브로커 접속 (publisher 측)
+        - host/port: 운영 환경 별도 안내 (현장 동일 내부망)
+        - 인증: username = device 식별자(예: BAND-A1B2C3), password = 디바이스 발급 키
+        - TLS: 현재 미사용 (평문 1883)
+        - QoS: 1 (At-Least-Once)
+        - retain: false
+    servers:
+      mqtt:
+        protocol: mqtt
+        host: ${MQTT_HOST:localhost}:${MQTT_PORT:1883}

--- a/apps/safers-collect/src/main/resources/application-local.yml
+++ b/apps/safers-collect/src/main/resources/application-local.yml
@@ -18,3 +18,8 @@ safety-collector:
   forwarder:
     batch-size: 100                                 # 한 번에 forward 할 envelope 수
     flush-interval-ms: 1000                         # @Scheduled fixedDelay (ms)
+  mqtt:
+    host: ${MQTT_HOST:localhost}                    # MQTT 브로커 호스트
+    port: ${MQTT_PORT:1883}                         # MQTT 브로커 포트 (평문)
+    client-id: ${MQTT_CLIENT_ID:safers-collect}     # broker 측 식별자
+    topic-prefix: safers/collect                    # 5개 토픽의 공통 prefix

--- a/apps/safers-collect/src/main/resources/application-prod.yml
+++ b/apps/safers-collect/src/main/resources/application-prod.yml
@@ -18,3 +18,8 @@ safety-collector:
   forwarder:
     batch-size: ${FORWARDER_BATCH_SIZE:100}
     flush-interval-ms: ${FORWARDER_FLUSH_INTERVAL_MS:1000}
+  mqtt:
+    host: ${MQTT_HOST}                              # MQTT 브로커 호스트 — 환경변수 필수
+    port: ${MQTT_PORT:1883}
+    client-id: ${MQTT_CLIENT_ID:safers-collect}
+    topic-prefix: ${MQTT_TOPIC_PREFIX:safers/collect}

--- a/apps/safers-collect/src/main/resources/application-prod.yml
+++ b/apps/safers-collect/src/main/resources/application-prod.yml
@@ -19,7 +19,7 @@ safety-collector:
     batch-size: ${FORWARDER_BATCH_SIZE:100}
     flush-interval-ms: ${FORWARDER_FLUSH_INTERVAL_MS:1000}
   mqtt:
-    host: ${MQTT_HOST}                              # MQTT 브로커 호스트 — 환경변수 필수
+    host: ${MQTT_HOST:}                             # 미설정 시 MQTT 구독 비활성 — REST API + Springwolf 문서만 동작
     port: ${MQTT_PORT:1883}
     client-id: ${MQTT_CLIENT_ID:safers-collect}
     topic-prefix: ${MQTT_TOPIC_PREFIX:safers/collect}

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarderTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/forwarder/TelemetryForwarderTest.kt
@@ -24,6 +24,13 @@ class TelemetryForwarderTest :
                         batchSize = 100,
                         flushIntervalMs = 1000,
                     ),
+                mqtt =
+                    SafersCollectProperties.Mqtt(
+                        host = "localhost",
+                        port = 1883,
+                        clientId = "test",
+                        topicPrefix = "safers/collect",
+                    ),
             )
 
         fun env(id: String) =

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicyTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/BackpressurePolicyTest.kt
@@ -22,6 +22,13 @@ class BackpressurePolicyTest :
                         batchSize = 100,
                         flushIntervalMs = 1000,
                     ),
+                mqtt =
+                    SafersCollectProperties.Mqtt(
+                        host = "localhost",
+                        port = 1883,
+                        clientId = "test",
+                        topicPrefix = "safers/collect",
+                    ),
             )
 
         fun env(id: String) =

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/ForwardQueueTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/queue/ForwardQueueTest.kt
@@ -22,6 +22,13 @@ class ForwardQueueTest :
                         batchSize = 100,
                         flushIntervalMs = 1000,
                     ),
+                mqtt =
+                    SafersCollectProperties.Mqtt(
+                        host = "localhost",
+                        port = 1883,
+                        clientId = "test",
+                        topicPrefix = "safers/collect",
+                    ),
             )
 
         fun queueOf(capacity: Int): ForwardQueue {

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandEventMqttHandlerTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandEventMqttHandlerTest.kt
@@ -1,0 +1,57 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.forwarder.dto.EventEnvelope
+import com.pluxity.safersCollect.v1.collect.adapter.BandEventAdapter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+class BandEventMqttHandlerTest :
+    BehaviorSpec({
+
+        val objectMapper: ObjectMapper =
+            JsonMapper
+                .builder()
+                .addModule(kotlinModule())
+                .build()
+        val adapter = BandEventAdapter()
+        val eventForwarder = mockk<EventForwarder>(relaxed = true)
+        val handler = BandEventMqttHandler(objectMapper, adapter, eventForwarder)
+
+        Given("BAND_FALL_DETECTED 이벤트 JSON 페이로드") {
+            val json =
+                """
+                {
+                  "eventId": "BAND-EVT-20260424-0001",
+                  "eventType": "BAND_FALL_DETECTED",
+                  "severity": "CRITICAL",
+                  "occurredAt": "2026-04-24T10:15:30",
+                  "payload": {
+                    "bandId": "BAND-A1B2C3",
+                    "impactG": 4.2
+                  }
+                }
+                """.trimIndent().toByteArray()
+
+            When("handle 호출") {
+                handler.handle(json)
+
+                Then("topicSuffix 는 band/events") {
+                    handler.topicSuffix shouldBe "band/events"
+                }
+
+                Then("EventForwarder.forward 가 envelope 1개로 호출됨") {
+                    val captured = slot<EventEnvelope>()
+                    verify(exactly = 1) { eventForwarder.forward(capture(captured)) }
+                    captured.captured.eventId shouldBe "BAND-EVT-20260424-0001"
+                    captured.captured.bandId shouldBe "BAND-A1B2C3"
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandTelemetryMqttHandlerTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/BandTelemetryMqttHandlerTest.kt
@@ -1,0 +1,54 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.queue.ForwardQueue
+import com.pluxity.safersCollect.v1.collect.adapter.BandTelemetryAdapter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+class BandTelemetryMqttHandlerTest :
+    BehaviorSpec({
+
+        val objectMapper: ObjectMapper =
+            JsonMapper
+                .builder()
+                .addModule(kotlinModule())
+                .build()
+        val adapter = BandTelemetryAdapter()
+        val queue = mockk<ForwardQueue>(relaxed = true)
+        val handler = BandTelemetryMqttHandler(objectMapper, adapter, queue)
+
+        Given("BandTelemetry 1건 JSON 페이로드") {
+            val json =
+                """
+                {
+                  "bandId": "BAND-A1B2C3",
+                  "timestamp": "2026-04-24T10:15:30",
+                  "vitals": {"heartRateBpm": 88, "bodyTempC": 36.7, "spo2": 97},
+                  "battery": 73,
+                  "wearState": "WORN"
+                }
+                """.trimIndent().toByteArray()
+
+            When("handle 호출") {
+                handler.handle(json)
+
+                Then("topicSuffix 는 band/telemetry") {
+                    handler.topicSuffix shouldBe "band/telemetry"
+                }
+
+                Then("ForwardQueue.enqueueAll 이 envelope 1개 collection 으로 호출됨") {
+                    val captured = slot<Collection<TelemetryEnvelope>>()
+                    verify(exactly = 1) { queue.enqueueAll(capture(captured)) }
+                    captured.captured.size shouldBe 1
+                    captured.captured.first().sourceId shouldBe "BAND-A1B2C3"
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasEventMqttHandlerTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasEventMqttHandlerTest.kt
@@ -1,0 +1,57 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.forwarder.dto.EventEnvelope
+import com.pluxity.safersCollect.v1.collect.adapter.GasEventAdapter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+class GasEventMqttHandlerTest :
+    BehaviorSpec({
+
+        val objectMapper: ObjectMapper =
+            JsonMapper
+                .builder()
+                .addModule(kotlinModule())
+                .build()
+        val adapter = GasEventAdapter()
+        val eventForwarder = mockk<EventForwarder>(relaxed = true)
+        val handler = GasEventMqttHandler(objectMapper, adapter, eventForwarder)
+
+        Given("GasEventRequest JSON 페이로드") {
+            val json =
+                """
+                {
+                  "eventId": "GAS-EVT-20260424-0001",
+                  "severity": "CRITICAL",
+                  "occurredAt": "2026-04-24T10:15:30",
+                  "payload": {
+                    "deviceId": "GAS-MH203-01",
+                    "triggered": [
+                      {"gas": "O2", "value": 3.1, "unit": "PPM", "threshold": 5.0, "level": "DANGER"}
+                    ]
+                  }
+                }
+                """.trimIndent().toByteArray()
+
+            When("handle 호출") {
+                handler.handle(json)
+
+                Then("topicSuffix 는 gas/events") {
+                    handler.topicSuffix shouldBe "gas/events"
+                }
+
+                Then("EventForwarder.forward 가 envelope 1개로 호출됨") {
+                    val captured = slot<EventEnvelope>()
+                    verify(exactly = 1) { eventForwarder.forward(capture(captured)) }
+                    captured.captured.eventId shouldBe "GAS-EVT-20260424-0001"
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasTelemetryMqttHandlerTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/GasTelemetryMqttHandlerTest.kt
@@ -1,0 +1,56 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.dto.TelemetryEnvelope
+import com.pluxity.safersCollect.queue.ForwardQueue
+import com.pluxity.safersCollect.v1.collect.adapter.GasTelemetryAdapter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+class GasTelemetryMqttHandlerTest :
+    BehaviorSpec({
+
+        val objectMapper: ObjectMapper =
+            JsonMapper
+                .builder()
+                .addModule(kotlinModule())
+                .build()
+        val adapter = GasTelemetryAdapter()
+        val queue = mockk<ForwardQueue>(relaxed = true)
+        val handler = GasTelemetryMqttHandler(objectMapper, adapter, queue)
+
+        Given("GasTelemetry 1건 JSON 페이로드") {
+            val json =
+                """
+                {
+                  "deviceId": "GAS-MH203-01",
+                  "timestamp": "2026-04-24T10:15:30",
+                  "measurements": [
+                    {"gas": "O2", "value": 3.1, "unit": "PPM"}
+                  ],
+                  "battery": 87,
+                  "signalRssi": -68
+                }
+                """.trimIndent().toByteArray()
+
+            When("handle 호출") {
+                handler.handle(json)
+
+                Then("topicSuffix 는 gas/telemetry") {
+                    handler.topicSuffix shouldBe "gas/telemetry"
+                }
+
+                Then("ForwardQueue.enqueueAll 이 envelope 1개 collection 으로 호출됨") {
+                    val captured = slot<Collection<TelemetryEnvelope>>()
+                    verify(exactly = 1) { queue.enqueueAll(capture(captured)) }
+                    captured.captured.size shouldBe 1
+                    captured.captured.first().sourceId shouldBe "GAS-MH203-01"
+                }
+            }
+        }
+    })

--- a/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/SosEventMqttHandlerTest.kt
+++ b/apps/safers-collect/src/test/kotlin/com/pluxity/safersCollect/v1/collect/mqtt/SosEventMqttHandlerTest.kt
@@ -1,0 +1,57 @@
+package com.pluxity.safersCollect.v1.collect.mqtt
+
+import com.pluxity.safersCollect.forwarder.EventForwarder
+import com.pluxity.safersCollect.forwarder.dto.EventEnvelope
+import com.pluxity.safersCollect.v1.collect.adapter.SosEventAdapter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+class SosEventMqttHandlerTest :
+    BehaviorSpec({
+
+        val objectMapper: ObjectMapper =
+            JsonMapper
+                .builder()
+                .addModule(kotlinModule())
+                .build()
+        val adapter = SosEventAdapter()
+        val eventForwarder = mockk<EventForwarder>(relaxed = true)
+        val handler = SosEventMqttHandler(objectMapper, adapter, eventForwarder)
+
+        Given("SOS BUTTON_LONG_PRESS 이벤트 JSON 페이로드") {
+            val json =
+                """
+                {
+                  "eventId": "SOS-EVT-20260424-0001",
+                  "severity": "CRITICAL",
+                  "occurredAt": "2026-04-24T10:15:30",
+                  "rawPosition": {"lat": 37.5, "lon": 127.0},
+                  "payload": {
+                    "bandId": "BAND-A1B2C3",
+                    "trigger": "BUTTON_LONG_PRESS"
+                  }
+                }
+                """.trimIndent().toByteArray()
+
+            When("handle 호출") {
+                handler.handle(json)
+
+                Then("topicSuffix 는 sos/events") {
+                    handler.topicSuffix shouldBe "sos/events"
+                }
+
+                Then("EventForwarder.forward 가 envelope 1개로 호출됨") {
+                    val captured = slot<EventEnvelope>()
+                    verify(exactly = 1) { eventForwarder.forward(capture(captured)) }
+                    captured.captured.eventId shouldBe "SOS-EVT-20260424-0001"
+                    captured.captured.bandId shouldBe "BAND-A1B2C3"
+                }
+            }
+        }
+    })

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,6 +91,7 @@ springdoc-common = { module = "org.springdoc:springdoc-openapi-starter-common", 
 # WebSocket
 springwolf-core = { module = "io.github.springwolf:springwolf-core", version.ref = "springwolf" }
 springwolf-stomp = { module = "io.github.springwolf:springwolf-stomp", version.ref = "springwolf" }
+springwolf-generic-binding = { module = "io.github.springwolf:springwolf-generic-binding", version.ref = "springwolf" }
 springwolf-ui = { module = "io.github.springwolf:springwolf-ui", version.ref = "springwolf" }
 
 # Kotlin JDSL

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,9 @@ springmockk = "5.0.1"
 # Influx
 influxdb = "7.3.0"
 
+# MQTT
+hivemq-mqtt-client = "1.3.14"
+
 [libraries]
 # Spring Boot Starters
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
@@ -68,6 +71,9 @@ kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 postgresql = { module = "org.postgresql:postgresql" }
 h2 = { module = "com.h2database:h2" }
 influxdb = {module = "com.influxdb:influxdb-client-java", version.ref = "influxdb"}
+
+# MQTT
+hivemq-mqtt-client = { module = "com.hivemq:hivemq-mqtt-client", version.ref = "hivemq-mqtt-client" }
 flyway-starter = { module = "org.springframework.boot:spring-boot-starter-flyway" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
 


### PR DESCRIPTION
## Summary

`apps/safers-collect`에 MQTT subscriber 인그레스를 추가했습니다. 기존 REST API와 동일한 5개 채널을 MQTT로도 수신 가능하며, Springwolf로 AsyncAPI 문서가 자동 생성되어 publisher(센서/디바이스) contract를 노출합니다.

- HiveMQ MQTT Client 1.3.14 Async API 기반 단일 `Mqtt5AsyncClient` Bean
- 채널별 핸들러 5개 (`MqttIngressHandler` 인터페이스 구현). payload → 기존 Adapter → 기존 Queue/Forwarder
- `MqttSubscriberStarter`가 `ApplicationReadyEvent`에서 connect + subscribe 일괄 수행, `@PreDestroy`에서 disconnect
- 모든 토픽 QoS 1
- Springwolf + `springwolf-generic-binding`으로 `/springwolf/asyncapi-ui.html`에 5개 채널 + payload schema + MQTT 바인딩 자동 문서화
- **MQTT host 미설정 시 자동 비활성** (`@ConditionalOnExpression`) — REST + Springwolf만으로도 정상 기동

## Topic 매핑

| 토픽 | 페이로드 DTO | 종착 |
|---|---|---|
| `safers/collect/gas/telemetry` | `GasTelemetry` | `ForwardQueue` |
| `safers/collect/gas/events` | `GasEventRequest` | `EventForwarder` |
| `safers/collect/band/telemetry` | `BandTelemetry` | `ForwardQueue` |
| `safers/collect/band/events` | `BandEventRequest` | `EventForwarder` |
| `safers/collect/sos/events` | `SosEventRequest` | `EventForwarder` |

## 변경 사항

**신규:**
- 5개 MQTT 핸들러 (`v1/collect/mqtt/*MqttHandler.kt`) + 각 단위 테스트
- `MqttIngressHandler` 인터페이스
- `MqttClientConfig` (Mqtt5AsyncClient Bean)
- `MqttSubscriberStarter` (라이프사이클)

**수정:**
- `gradle/libs.versions.toml` — `hivemq-mqtt-client`, `springwolf-generic-binding` 추가
- `apps/safers-collect/build.gradle.kts` — HiveMQ + Springwolf 의존성
- `SafersCollectProperties` — `Mqtt` 중첩 프로퍼티 추가 (기본값 부여로 yml 누락 시에도 바인딩 통과)
- `application-common.yml` — springwolf 블록
- `application-local.yml`, `application-prod.yml` — `safety-collector.mqtt.*`
- 기존 테스트 3개 (`ForwardQueueTest`, `BackpressurePolicyTest`, `TelemetryForwarderTest`) — `Mqtt` 필드 fixture 추가

**무변경:** 기존 `*Adapter`, `ForwardQueue`, `EventForwarder`, `*Controller`, REST DTO

## 핵심 설계 포인트

- **MQTT host 미설정 시 안전 기동**: `@ConditionalOnExpression($$"'\${safety-collector.mqtt.host:}' != ''")` 로 broker 비활성 환경에서도 앱 부팅 + REST + Springwolf 정상 동작
- **`!!` 회피**: `Mqtt` 모든 필드에 기본값 + 부모에 `= Mqtt()` 부여 → 어떤 yml 구성에서도 null 체크 불필요
- **transport-neutral 핸들러**: `MqttIngressHandler.handle(payload: ByteArray)` 좁은 인터페이스 — broker 없이 단위 테스트 가능, MQTT 외 transport로 재활용 여지

## Test plan

- [x] `./gradlew :apps:safers-collect:build` — 컴파일/spotless/테스트 전부 통과
- [x] 핸들러 단위 테스트 5개 추가
- [x] 기존 테스트 회귀 통과
- [ ] HiveMQ broker(CE) 띄우고 5개 토픽 각각 publish → 핸들러 처리 로그 확인
- [ ] `http://localhost:8080/springwolf/asyncapi-ui.html` 에서 5개 채널 + payload schema + `mqtt: qos=1, retain=false` 바인딩 노출 확인
- [ ] `MQTT_HOST` 미설정 상태에서 앱 기동 → MQTT 비활성, REST + Springwolf만 동작 확인

## 후속 과제 (이 PR 밖)

- HiveMQ 임베디드 브로커/Testcontainers 기반 E2E 통합 테스트
- payload 검증 (`jakarta.validation`이 MQTT 경로엔 미적용)
- Dead-letter 토픽 (파싱 실패 시 raw payload → `safers/collect/dlq/...`)
- 메트릭 (subscribe별 in/error 카운트, MeterRegistry)
- TLS/mTLS + broker 인증 extension(`hivemq-file-rbac-extension` 등)
- forwarder backoff + max retry + DLQ (현재 무한 1초 재시도라 중앙 다운 시 로그 도배)
- Springwolf AsyncAPI JSON CI export → 센서 SDK 레포로 자동 배포